### PR TITLE
Unmap color arrays

### DIFF
--- a/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
+++ b/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
@@ -71,6 +71,9 @@
         <property name="text">
          <string>Map Scalars</string>
         </property>
+        <property name="tristate">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item row="3" column="0">

--- a/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
@@ -69,14 +69,21 @@ void VSAbstractViewWidget::copyFilters(VSFilterViewSettings::Container filters)
     VSFilterViewSettings* viewSettings = new VSFilterViewSettings(*(filters[i]));
     m_FilterViewSettings[i] = viewSettings;
 
-    connect(viewSettings, SIGNAL(filterAdded(VSAbstractFilter*)), this, SLOT(filterAdded(VSAbstractFilter*)));
-    connect(viewSettings, SIGNAL(filterRemoved(VSAbstractFilter*)), this, SLOT(filterRemoved(VSAbstractFilter*)));
+    connect(viewSettings, SIGNAL(filterAdded(VSAbstractFilter*)), 
+      this, SLOT(filterAdded(VSAbstractFilter*)));
+    connect(viewSettings, SIGNAL(filterRemoved(VSAbstractFilter*)), 
+      this, SLOT(filterRemoved(VSAbstractFilter*)));
     
-    connect(viewSettings, SIGNAL(visibilityChanged(VSFilterViewSettings*, bool)), this, SLOT(setFilterVisibility(VSFilterViewSettings*, bool)));
-    connect(viewSettings, SIGNAL(activeArrayIndexChanged(VSFilterViewSettings*, int)), this, SLOT(setFilterArrayIndex(VSFilterViewSettings*, int)));
-    connect(viewSettings, SIGNAL(activeComponentIndexChanged(VSFilterViewSettings*, int)), this, SLOT(setFilterComponentIndex(VSFilterViewSettings*, int)));
-    connect(viewSettings, SIGNAL(mapColorsChanged(VSFilterViewSettings*, bool)), this, SLOT(setFilterMapColors(VSFilterViewSettings*, bool)));
-    connect(viewSettings, SIGNAL(showScalarBarChanged(VSFilterViewSettings*, bool)), this, SLOT(setFilterShowScalarBar(VSFilterViewSettings*, bool)));
+    connect(viewSettings, SIGNAL(visibilityChanged(VSFilterViewSettings*, bool)), 
+      this, SLOT(setFilterVisibility(VSFilterViewSettings*, bool)));
+    connect(viewSettings, SIGNAL(activeArrayIndexChanged(VSFilterViewSettings*, int)), 
+      this, SLOT(setFilterArrayIndex(VSFilterViewSettings*, int)));
+    connect(viewSettings, SIGNAL(activeComponentIndexChanged(VSFilterViewSettings*, int)), 
+      this, SLOT(setFilterComponentIndex(VSFilterViewSettings*, int)));
+    connect(viewSettings, SIGNAL(mapColorsChanged(VSFilterViewSettings*, Qt::CheckState)), 
+      this, SLOT(setFilterMapColors(VSFilterViewSettings*, Qt::CheckState)));
+    connect(viewSettings, SIGNAL(showScalarBarChanged(VSFilterViewSettings*, bool)), 
+      this, SLOT(setFilterShowScalarBar(VSFilterViewSettings*, bool)));
     connect(viewSettings, SIGNAL(requiresRender()), this, SLOT(renderView()));
 
     checkFilterViewSetting(viewSettings);
@@ -120,8 +127,8 @@ void VSAbstractViewWidget::filterAdded(VSAbstractFilter* filter)
     this, SLOT(setFilterArrayIndex(VSFilterViewSettings*, int)));
   connect(viewSettings, SIGNAL(activeComponentIndexChanged(VSFilterViewSettings*, int)), 
     this, SLOT(setFilterComponentIndex(VSFilterViewSettings*, int)));
-  connect(viewSettings, SIGNAL(mapColorsChanged(VSFilterViewSettings*, bool)), 
-    this, SLOT(setFilterMapColors(VSFilterViewSettings*, bool)));
+  connect(viewSettings, SIGNAL(mapColorsChanged(VSFilterViewSettings*, Qt::CheckState)),
+    this, SLOT(setFilterMapColors(VSFilterViewSettings*, Qt::CheckState)));
   connect(viewSettings, SIGNAL(showScalarBarChanged(VSFilterViewSettings*, bool)), 
     this, SLOT(setFilterShowScalarBar(VSFilterViewSettings*, bool)));
   connect(viewSettings, SIGNAL(requiresRender()), this, SLOT(renderView()));
@@ -303,7 +310,7 @@ void VSAbstractViewWidget::setFilterComponentIndex(VSFilterViewSettings* viewSet
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSAbstractViewWidget::setFilterMapColors(VSFilterViewSettings* viewSettings, bool mapColors)
+void VSAbstractViewWidget::setFilterMapColors(VSFilterViewSettings* viewSettings, int mapColorState)
 {
   renderView();
 }
@@ -357,11 +364,11 @@ void VSAbstractViewWidget::changeFilterComponentIndex(int index)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSAbstractViewWidget::changeFilterMapColors(bool mapColors)
+void VSAbstractViewWidget::changeFilterMapColors(Qt::CheckState mapColorState)
 {
   if(m_ActiveFilterSettings)
   {
-    m_ActiveFilterSettings->setMapColors(mapColors);
+    m_ActiveFilterSettings->setMapColors(mapColorState);
   }
 }
 
@@ -597,8 +604,8 @@ void VSAbstractViewWidget::setController(VSController* controller)
       this, SLOT(setFilterArrayIndex(VSFilterViewSettings*, int)));
     connect(viewSettings, SIGNAL(activeComponentIndexChanged(VSFilterViewSettings*, int)), 
       this, SLOT(setFilterComponentIndex(VSFilterViewSettings*, int)));
-    connect(viewSettings, SIGNAL(mapColorsChanged(VSFilterViewSettings*, bool)), 
-      this, SLOT(setFilterMapColors(VSFilterViewSettings*, bool)));
+    connect(viewSettings, SIGNAL(mapColorsChanged(VSFilterViewSettings*, Qt::CheckState)),
+      this, SLOT(setFilterMapColors(VSFilterViewSettings*, Qt::CheckState)));
     connect(viewSettings, SIGNAL(showScalarBarChanged(VSFilterViewSettings*, bool)), 
       this, SLOT(setFilterShowScalarBar(VSFilterViewSettings*, bool)));
     connect(viewSettings, SIGNAL(requiresRender()), this, SLOT(renderView()));

--- a/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.h
+++ b/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.h
@@ -122,7 +122,7 @@ signals:
   void visibilityChanged(VSFilterViewSettings*, bool);
   void activeArrayIndexChanged(VSFilterViewSettings*, int);
   void activeComponentIndexChanged(VSFilterViewSettings*, int);
-  void mapColorsChanged(VSFilterViewSettings*, bool);
+  void mapColorsChanged(VSFilterViewSettings*, Qt::CheckState);
   void alphaChanged(VSFilterViewSettings*, double);
   void showScalarBarChanged(VSFilterViewSettings*, bool);
   void requiresRender();
@@ -187,9 +187,9 @@ protected slots:
 
   /**
   * @brief Change the active filter's color map setting
-  * @param mapColors
+  * @param mapColorState
   */
-  void changeFilterMapColors(bool mapColors);
+  void changeFilterMapColors(Qt::CheckState mapColorState);
 
   /**
   * @brief Change the active filter's scalar bar visibility
@@ -216,7 +216,7 @@ protected slots:
   * @param viewSettings
   * @param mapColors
   */
-  virtual void setFilterMapColors(VSFilterViewSettings* viewSettings, bool mapColors);
+  virtual void setFilterMapColors(VSFilterViewSettings* viewSettings, int mapColorState);
 
   /**
   * @brief ScalarBar visibility changed for filter

--- a/SIMPLVtkLib/QtWidgets/VSInfoWidget.h
+++ b/SIMPLVtkLib/QtWidgets/VSInfoWidget.h
@@ -143,6 +143,41 @@ protected slots:
   */
   void alphaSliderMoved(int value);
 
+  /**
+  * @brief Listens for the active VSFilterViewSettings active array index to change
+  * @param settings
+  * @param index
+  */
+  void listenArrayIndex(VSFilterViewSettings* settings, int index);
+
+  /**
+  * @brief Listens for the active VSFilterViewSettings active component index to change
+  * @param settings
+  * @param index
+  */
+  void listenComponentIndex(VSFilterViewSettings* settings, int index);
+
+  /**
+  * @brief Listens for the active VSFilterViewSettings map colors value to change
+  * @param settings
+  * @param state
+  */
+  void listenMapColors(VSFilterViewSettings* settings, Qt::CheckState state);
+
+  /**
+  * @brief Listens for the active VSFilterViewSettings alpha value to change
+  * @param settings
+  * @param alpha
+  */
+  void listenAlpha(VSFilterViewSettings* settings, double alpha);
+
+  /**
+  * @brief Listens for the active VSFilterViewSettings scalar bar visibility to change
+  * @param settings
+  * @param show
+  */
+  void listenScalarBar(VSFilterViewSettings* settings, bool show);
+
 protected:
   /**
   * @brief Performs initial setup for the GUI
@@ -157,6 +192,12 @@ protected:
   * @brief Updates the information on the VSFilterViewSettings
   */
   void updateViewSettingInfo();
+
+  /**
+  * @brief Connects to the given VSFilterViewSettings to take advantage of its signals and slots
+  * @param settings
+  */
+  void connectFilterViewSettings(VSFilterViewSettings* settings);
 
 private:
   class VSInternals;

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -137,7 +137,7 @@ int VSFilterViewSettings::getNumberOfComponents(QString arrayName)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool VSFilterViewSettings::getMapColors()
+Qt::CheckState VSFilterViewSettings::getMapColors()
 {
   return m_MapColors;
 }
@@ -230,9 +230,9 @@ void VSFilterViewSettings::setActiveArrayIndex(int index)
   emit activeArrayIndexChanged(this, m_ActiveArray);
   setActiveComponentIndex(-1);
 
-  if(isColorArray(dataArray))
+  if(isColorArray(dataArray) && m_MapColors == Qt::Checked)
   {
-    setMapColors(false);
+    setMapColors(Qt::CheckState::PartiallyChecked);
   }
 }
 
@@ -329,8 +329,9 @@ void VSFilterViewSettings::updateColorMode()
   }
 
   vtkDataArray* dataArray = getDataArray();
+  bool unmapColorArray = isColorArray(dataArray) && (m_ActiveComponent == -1);
 
-  if(m_MapColors && !isColorArray(dataArray))
+  if(m_MapColors && !unmapColorArray)
   {
     m_Mapper->SetColorModeToMapScalars();
   }
@@ -345,12 +346,13 @@ void VSFilterViewSettings::updateColorMode()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSFilterViewSettings::setMapColors(bool mapColors)
+void VSFilterViewSettings::setMapColors(Qt::CheckState mapColorState)
 {
-  m_MapColors = mapColors;
+  m_MapColors = mapColorState;
 
   updateColorMode();
   emit mapColorsChanged(this, m_MapColors);
+  emit requiresRender();
 }
 
 // -----------------------------------------------------------------------------
@@ -469,7 +471,7 @@ void VSFilterViewSettings::connectFilter(VSAbstractFilter* filter)
     if(filter->getArrayNames().size() < 1)
     {
       setScalarBarVisible(false);
-      setMapColors(false);
+      setMapColors(Qt::Unchecked);
     }
   }
 }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -228,7 +228,12 @@ void VSFilterViewSettings::setActiveArrayIndex(int index)
   m_ActiveArray = index;
 
   emit activeArrayIndexChanged(this, m_ActiveArray);
-  setActiveComponentIndex(-1); 
+  setActiveComponentIndex(-1);
+
+  if(isColorArray(dataArray))
+  {
+    setMapColors(false);
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -268,8 +273,6 @@ void VSFilterViewSettings::setActiveComponentIndex(int index)
     QString dataArrayName = QString(dataArray->GetName());
     QString componentName = dataArrayName + " Magnitude";
 
-    //lookupTable->SetVectorModeToMagnitude();
-  
     m_LookupTable->setRange(range);
     m_ScalarBarActor->SetTitle(qPrintable(componentName));
   }
@@ -288,6 +291,36 @@ void VSFilterViewSettings::setActiveComponentIndex(int index)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+vtkDataArray* VSFilterViewSettings::getDataArray()
+{
+  if(nullptr == m_Filter->getOutput())
+  {
+    return nullptr;
+  }
+
+  return getArrayAtIndex(m_ActiveArray);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+bool VSFilterViewSettings::isColorArray(vtkDataArray* dataArray)
+{
+  if(dataArray->GetNumberOfComponents() == 3)
+  {
+    QString dataType = dataArray->GetDataTypeAsString();
+    if(dataType.compare("unsigned char") == 0)
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void VSFilterViewSettings::updateColorMode()
 {
   if(nullptr == m_Mapper)
@@ -295,7 +328,9 @@ void VSFilterViewSettings::updateColorMode()
     return;
   }
 
-  if(m_MapColors)
+  vtkDataArray* dataArray = getDataArray();
+
+  if(m_MapColors && !isColorArray(dataArray))
   {
     m_Mapper->SetColorModeToMapScalars();
   }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
@@ -120,10 +120,10 @@ public:
   int getNumberOfComponents(QString name);
 
   /**
-  * @brief Returns true if the filter values are mapped to a lookup table.  Returns false otherwise
+  * @brief Returns the check state for mapping filter values to a lookup table.
   * @return
   */
-  bool getMapColors();
+  Qt::CheckState getMapColors();
 
   /**
   * @brief Returns tha alpha transparency used for the displaying the actor
@@ -187,7 +187,7 @@ public slots:
   * @brief Updates whether or not the data values are mapped to the lookup table for this view
   * @param mapColors
   */
-  void setMapColors(bool mapColors);
+  void setMapColors(Qt::CheckState mapColorState);
 
   /**
   * @brief Sets the object's alpha transparency
@@ -223,7 +223,7 @@ signals:
   void visibilityChanged(VSFilterViewSettings*, bool);
   void activeArrayIndexChanged(VSFilterViewSettings*, int);
   void activeComponentIndexChanged(VSFilterViewSettings*, int);
-  void mapColorsChanged(VSFilterViewSettings*, bool);
+  void mapColorsChanged(VSFilterViewSettings*, Qt::CheckState);
   void alphaChanged(VSFilterViewSettings*, double);
   void showScalarBarChanged(VSFilterViewSettings*, bool);
   void requiresRender();
@@ -269,7 +269,7 @@ private:
   bool m_ShowFilter = true;
   int m_ActiveArray = 0;
   int m_ActiveComponent = -1;
-  bool m_MapColors = true;
+  Qt::CheckState m_MapColors = Qt::Checked;
   VTK_PTR(vtkMapper) m_Mapper = nullptr;
   VTK_PTR(vtkActor) m_Actor = nullptr;
   bool m_ShowScalarBar = true;

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
@@ -252,6 +252,18 @@ protected:
   */
   void updateColorMode();
 
+  /**
+  * @brief Returns true if the given array is a 3-Component color array
+  * @param array
+  * @return
+  */
+  bool isColorArray(vtkDataArray* array);
+
+  /**
+  * @brief Returns the current vtkDataArray specified by the given array index
+  */
+  vtkDataArray* getDataArray();
+
 private:
   VSAbstractFilter* m_Filter = nullptr;
   bool m_ShowFilter = true;


### PR DESCRIPTION
Allows color arrays (3-component unsigned char) to be unmapped when displaying their magnitude.  This requires the map scalars value to be partially checked.  Setting the value to Qt::Checked will force mapping even for displaying the magnitude.

The VSInfoWidget now listens directly to the active VSFilterViewSettings and changes the values that are displayed as values are changed.