### PR TITLE
Feature/filter model

### DIFF
--- a/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
@@ -37,6 +37,8 @@
 
 #include <QtWidgets/QLayout>
 
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.h"
+
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -128,7 +130,7 @@ void VSAbstractViewWidget::filterAdded(VSAbstractFilter* filter)
 
   m_FilterViewSettings.push_back(viewSettings);
 
-  if(filter->getParentFilter())
+  if(filter->getParentFilter() && filter->getParentFilter()->getOutput())
   {
     VSFilterViewSettings* parentSettings = getFilterViewSettings(filter->getParentFilter());
     if(parentSettings)
@@ -138,6 +140,11 @@ void VSAbstractViewWidget::filterAdded(VSAbstractFilter* filter)
   }
 
   checkFilterViewSetting(viewSettings);
+
+  if(dynamic_cast<VSDataSetFilter*>(filter))
+  {
+    getVisualizationWidget()->resetCamera();
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -180,6 +187,11 @@ void VSAbstractViewWidget::checkFilterViewSetting(VSFilterViewSettings* setting)
   {
     return;
   }
+  else if(nullptr == setting->getScalarBarWidget())
+  {
+    return;
+  }
+
   setting->getScalarBarWidget()->SetInteractor(getVisualizationWidget()->GetInteractor());
 
   setFilterVisibility(setting, setting->getVisible());
@@ -252,6 +264,10 @@ int VSAbstractViewWidget::getViewSettingsIndex(VSFilterViewSettings* settings)
 void VSAbstractViewWidget::setFilterVisibility(VSFilterViewSettings* viewSettings, bool filterVisible)
 {
   if(nullptr == viewSettings)
+  {
+    return;
+  }
+  if(false == viewSettings->isValid())
   {
     return;
   }

--- a/SIMPLVtkLib/QtWidgets/VSFilterView.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterView.cpp
@@ -127,6 +127,32 @@ void VSFilterView::setFilterVisibility(VSFilterViewSettings* filterSettings, boo
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+void VSFilterView::setActiveFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* widget)
+{
+  VSFilterModel* filterModel = dynamic_cast<VSFilterModel*>(model());
+  if(nullptr == filterModel)
+  {
+    return;
+  }
+  if(nullptr == selectionModel())
+  {
+    return;
+  }
+
+  QModelIndex currentIndex = selectionModel()->currentIndex();
+  QModelIndex newIndex = filterModel->getIndexFromFilter(filter);
+
+  // Do not update the selection if there is no change
+  if(newIndex != currentIndex)
+  {
+    QFlags<QItemSelectionModel::SelectionFlag> flags = QItemSelectionModel::ClearAndSelect;
+    selectionModel()->setCurrentIndex(newIndex, flags);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void VSFilterView::itemClicked(const QModelIndex& index)
 {
   VSAbstractFilter* filter = getFilterFromIndex(index);

--- a/SIMPLVtkLib/QtWidgets/VSFilterView.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterView.h
@@ -90,6 +90,13 @@ protected slots:
   void itemClicked(const QModelIndex& index);
 
   /**
+  * @brief Handles changes in the current item
+  * @param current
+  * @param previous
+  */
+  void setCurrentItem(const QModelIndex& current, const QModelIndex& previous);
+
+  /**
   * @brief Handles a new filter being inserted and automatically expands it
   * @param filter
   */

--- a/SIMPLVtkLib/QtWidgets/VSFilterView.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterView.h
@@ -81,6 +81,13 @@ public slots:
   */
   void setFilterVisibility(VSFilterViewSettings* filter, bool visible);
 
+  /**
+  * @brief Handles changing the active filter through other widgets or controls
+  * @param filter
+  * @param widget
+  */
+  void setActiveFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* widget);
+
 protected slots:
   /**
   * @brief Handles mouse clicks on an item and emits a signal if the item is a

--- a/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
@@ -159,10 +159,6 @@ void VSInfoWidget::setFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* f
   m_FilterWidget = filterWidget;
 
   bool filterExists = (nullptr != filter);
-  m_Internals->applyBtn->setEnabled(filterExists);
-  m_Internals->resetBtn->setEnabled(filterExists);
-  m_Internals->deleteBtn->setEnabled(filterExists);
-
   if(filterExists && m_ViewWidget)
   {
     m_ViewSettings = m_ViewWidget->getFilterViewSettings(m_Filter);
@@ -172,7 +168,21 @@ void VSInfoWidget::setFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* f
     m_ViewSettings = nullptr;
   }
 
-  if (filterWidget != nullptr)
+  // Check if VSFilterSettings exist and are valid
+  bool viewSettingsValid;
+  if(m_ViewSettings && m_ViewSettings->isValid())
+  {
+    viewSettingsValid = filterExists;
+  }
+  else
+  {
+    viewSettingsValid = false;
+  }
+  m_Internals->applyBtn->setEnabled(viewSettingsValid);
+  m_Internals->resetBtn->setEnabled(viewSettingsValid);
+  m_Internals->deleteBtn->setEnabled(viewSettingsValid);
+
+  if(filterWidget != nullptr)
   {
     m_Internals->gridLayout_4->addWidget(filterWidget);
   }
@@ -247,7 +257,8 @@ void VSInfoWidget::updateViewSettingInfo()
   }
 
   // Apply the current filter view settings to the widget
-  m_Internals->viewSettingsWidget->setEnabled(true);
+  bool validSettings = m_ViewSettings && m_ViewSettings->isValid();
+  m_Internals->viewSettingsWidget->setEnabled(validSettings);
 
   int activeArrayIndex = m_ViewSettings->getActiveArrayIndex();
   int activeComponentIndex = m_ViewSettings->getActiveComponentIndex() + 1;

--- a/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
@@ -124,13 +124,17 @@ void VSMainWidgetBase::setFilterView(VSFilterView* view)
   {
     disconnect(m_FilterView, SIGNAL(filterClicked(VSAbstractFilter*)));
     disconnect(this, SIGNAL(changedActiveView(VSAbstractViewWidget*)), view, SLOT(changeViewWidget(VSAbstractViewWidget*)));
+    disconnect(this, SIGNAL(changedActiveFilter(VSAbstractFilter*, VSAbstractFilterWidget*)),
+      view, SLOT(setActiveFilter(VSAbstractFilter*, VSAbstractFilterWidget*)));
   }
 
   view->setController(m_Controller);
 
   m_FilterView = view;
   connect(view, SIGNAL(filterClicked(VSAbstractFilter*)), this, SLOT(setCurrentFilter(VSAbstractFilter*)));
-  connect(this, SIGNAL(changedActiveView(VSAbstractViewWidget*)), view, SLOT(changeViewWidget(VSAbstractViewWidget*)));
+  connect(this, SIGNAL(changedActiveView(VSAbstractViewWidget*)), view, SLOT(setViewWidget(VSAbstractViewWidget*)));
+  connect(this, SIGNAL(changedActiveFilter(VSAbstractFilter*, VSAbstractFilterWidget*)),
+    view, SLOT(setActiveFilter(VSAbstractFilter*, VSAbstractFilterWidget*)));
   
   view->setViewWidget(m_ActiveViewWidget);
 }

--- a/SIMPLVtkLib/Visualization/Controllers/VSController.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSController.cpp
@@ -60,11 +60,11 @@ VSController::~VSController()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSController::importData(QString textLabel, DataContainerArray::Pointer dca)
+void VSController::importData(QString textLabel, QString tooltip, DataContainerArray::Pointer dca)
 {
   std::vector<SIMPLVtkBridge::WrappedDataContainerPtr> wrappedData = SIMPLVtkBridge::WrapDataContainerArrayAsStruct(dca);
 
-  VSTextFilter* textFilter = new VSTextFilter(nullptr, textLabel);
+  VSTextFilter* textFilter = new VSTextFilter(nullptr, textLabel, tooltip);
   m_FilterModel->addFilter(textFilter);
 
   // Add VSDataSetFilter for each DataContainer with relevant data

--- a/SIMPLVtkLib/Visualization/Controllers/VSController.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSController.h
@@ -73,7 +73,7 @@ public:
   * as top-level VisualFilters
   * @param dca
   */
-  void importData(QString textLabel, DataContainerArray::Pointer dca);
+  void importData(QString textLabel, QString tooltip, DataContainerArray::Pointer dca);
 
   /**
   * @brief Import data from a DataContainerArray and add any relevant DataContainers

--- a/SIMPLVtkLib/Visualization/Controllers/VSController.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSController.h
@@ -42,6 +42,7 @@
 
 #include "SIMPLVtkLib/SIMPLBridge/SIMPLVtkBridge.h"
 #include "SIMPLVtkLib/Visualization/Controllers/VSFilterModel.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h"
 
 #include "SIMPLVtkLib/SIMPLVtkLib.h"
 
@@ -72,6 +73,13 @@ public:
   * as top-level VisualFilters
   * @param dca
   */
+  void importData(QString textLabel, DataContainerArray::Pointer dca);
+
+  /**
+  * @brief Import data from a DataContainerArray and add any relevant DataContainers
+  * as top-level VisualFilters
+  * @param dca
+  */
   void importData(DataContainerArray::Pointer dca);
 
   /**
@@ -80,6 +88,13 @@ public:
   * @param dc
   */
   void importData(DataContainer::Pointer dc);
+
+  /**
+  * @brief Returns the first top level text filter with the given value;
+  * @param text
+  * @return
+  */
+  VSTextFilter* getBaseTextFilter(QString text);
 
   /**
   * @brief Returns a vector of top-level data filters

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -355,6 +355,11 @@ vtkDataArray* VSFilterViewSettings::getDataArray()
 // -----------------------------------------------------------------------------
 bool VSFilterViewSettings::isColorArray(vtkDataArray* dataArray)
 {
+  if(nullptr == dataArray)
+  {
+    return false;
+  }
+
   if(dataArray->GetNumberOfComponents() == 3)
   {
     QString dataType = dataArray->GetDataTypeAsString();

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -68,7 +68,11 @@ VSFilterViewSettings::VSFilterViewSettings(const VSFilterViewSettings& copy)
 {
   connectFilter(copy.m_Filter);
   setupActors();
-  m_LookupTable->copy(*(copy.m_LookupTable));
+
+  if(copy.m_LookupTable)
+  {
+    m_LookupTable->copy(*(copy.m_LookupTable));
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -76,10 +80,6 @@ VSFilterViewSettings::VSFilterViewSettings(const VSFilterViewSettings& copy)
 // -----------------------------------------------------------------------------
 VSFilterViewSettings::~VSFilterViewSettings()
 {
-  //if(m_LookupTable)
-  //{
-  //  delete m_LookupTable;
-  //}
 }
 
 // -----------------------------------------------------------------------------
@@ -88,6 +88,15 @@ VSFilterViewSettings::~VSFilterViewSettings()
 VSAbstractFilter* VSFilterViewSettings::getFilter()
 {
   return m_Filter;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+bool VSFilterViewSettings::isValid()
+{
+  bool valid = m_Mapper && m_Actor && m_ScalarBarWidget;
+  return valid;
 }
 
 // -----------------------------------------------------------------------------
@@ -119,8 +128,18 @@ int VSFilterViewSettings::getActiveComponentIndex()
 // -----------------------------------------------------------------------------
 int VSFilterViewSettings::getNumberOfComponents(int arrayIndex)
 {
+  if(nullptr == m_Filter->getOutput())
+  {
+    return -1;
+  }
+
   vtkCellData* cellData = m_Filter->getOutput()->GetCellData();
-  return cellData->GetAbstractArray(arrayIndex)->GetNumberOfComponents();
+  vtkAbstractArray* array = cellData->GetAbstractArray(arrayIndex);
+  if(array)
+  {
+    return array->GetNumberOfComponents();
+  }
+  return 0;
 }
 
 // -----------------------------------------------------------------------------
@@ -128,10 +147,20 @@ int VSFilterViewSettings::getNumberOfComponents(int arrayIndex)
 // -----------------------------------------------------------------------------
 int VSFilterViewSettings::getNumberOfComponents(QString arrayName)
 {
+  if(nullptr == m_Filter->getOutput())
+  {
+    return -1;
+  }
+
   const char* name = arrayName.toLatin1();
 
   vtkCellData* cellData = m_Filter->getOutput()->GetCellData();
-  return cellData->GetAbstractArray(name)->GetNumberOfComponents();
+  vtkAbstractArray* array = cellData->GetAbstractArray(name);
+  if(array)
+  {
+    return array->GetNumberOfComponents();
+  }
+  return 0;
 }
 
 // -----------------------------------------------------------------------------
@@ -195,6 +224,11 @@ void VSFilterViewSettings::hide()
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::setVisible(bool visible)
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   m_ShowFilter = visible;
 
   emit visibilityChanged(this, m_ShowFilter);
@@ -205,6 +239,11 @@ void VSFilterViewSettings::setVisible(bool visible)
 // -----------------------------------------------------------------------------
 vtkDataArray* VSFilterViewSettings::getArrayAtIndex(int index)
 {
+  if(false == isValid())
+  {
+    return nullptr;
+  }
+
   vtkDataSet* dataSet = m_Mapper->GetInput();
   if(dataSet && dataSet->GetCellData())
   {
@@ -219,6 +258,11 @@ vtkDataArray* VSFilterViewSettings::getArrayAtIndex(int index)
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::setActiveArrayIndex(int index)
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   VTK_PTR(vtkDataArray) dataArray = getArrayAtIndex(index);
   if(nullptr == dataArray)
   {
@@ -236,6 +280,11 @@ void VSFilterViewSettings::setActiveArrayIndex(int index)
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::setActiveComponentIndex(int index)
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   m_ActiveComponent = index;
 
   VTK_PTR(vtkScalarsToColors) lookupTable = m_Mapper->GetLookupTable();
@@ -290,7 +339,7 @@ void VSFilterViewSettings::setActiveComponentIndex(int index)
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::updateColorMode()
 {
-  if(nullptr == m_Mapper)
+  if(false == isValid())
   {
     return;
   }
@@ -312,6 +361,11 @@ void VSFilterViewSettings::updateColorMode()
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::setMapColors(bool mapColors)
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   m_MapColors = mapColors;
 
   updateColorMode();
@@ -323,6 +377,11 @@ void VSFilterViewSettings::setMapColors(bool mapColors)
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::setAlpha(double alpha)
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   if(alpha < 0.0)
   {
     alpha = 0.0;
@@ -347,6 +406,11 @@ void VSFilterViewSettings::setAlpha(double alpha)
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::invertScalarBar()
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   m_LookupTable->invert();
   emit requiresRender();
 }
@@ -356,6 +420,11 @@ void VSFilterViewSettings::invertScalarBar()
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::loadPresetColors(const QJsonObject& colors)
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   m_LookupTable->parseRgbJson(colors);
   emit requiresRender();
 }
@@ -365,6 +434,11 @@ void VSFilterViewSettings::loadPresetColors(const QJsonObject& colors)
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::setScalarBarVisible(bool visible)
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   m_ShowScalarBar = visible;
 
   emit showScalarBarChanged(this, m_ShowScalarBar);
@@ -375,6 +449,13 @@ void VSFilterViewSettings::setScalarBarVisible(bool visible)
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::setupActors()
 {
+  VTK_PTR(vtkDataSet) outputData = m_Filter->getOutput();
+  if(nullptr == outputData)
+  {
+    m_ShowFilter = false;
+    return;
+  }
+
   m_Mapper = VTK_PTR(vtkDataSetMapper)::New();
   m_Mapper->SetInputConnection(m_Filter->getOutputPort());
 
@@ -402,9 +483,17 @@ void VSFilterViewSettings::setupActors()
   m_ScalarBarActor->SetTitleRatio(0.75);
 
   // Set Mapper to use the active array and component
-  int currentComponent = m_ActiveComponent;
-  setActiveArrayIndex(m_ActiveArray);
-  setActiveComponentIndex(currentComponent);
+  if(outputData->GetCellData()->GetNumberOfArrays() > 0)
+  {
+    int currentComponent = m_ActiveComponent;
+    setActiveArrayIndex(m_ActiveArray);
+    setActiveComponentIndex(m_ActiveComponent);
+  }
+  else
+  {
+    setMapColors(false);
+    setScalarBarVisible(false);
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -412,6 +501,11 @@ void VSFilterViewSettings::setupActors()
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::updateInputPort(VSAbstractFilter* filter)
 {
+  if(false == isValid())
+  {
+    return;
+  }
+
   m_Mapper->SetInputConnection(filter->getOutputPort());
   emit requiresRender();
 }
@@ -444,8 +538,17 @@ void VSFilterViewSettings::connectFilter(VSAbstractFilter* filter)
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::copySettings(VSFilterViewSettings* copy)
 {
-  vtkRenderWindowInteractor* iren = copy->m_ScalarBarWidget->GetInteractor();
-  m_ScalarBarWidget->SetInteractor(iren);
+  if((nullptr == copy) || (false == copy->isValid()))
+  {
+    return;
+  }
+
+  bool hasUi = copy->getScalarBarWidget();
+  if(hasUi)
+  {
+    vtkRenderWindowInteractor* iren = copy->m_ScalarBarWidget->GetInteractor();
+    m_ScalarBarWidget->SetInteractor(iren);
+  }
 
   setVisible(copy->m_ShowFilter);
   setActiveArrayIndex(copy->m_ActiveArray);
@@ -454,7 +557,10 @@ void VSFilterViewSettings::copySettings(VSFilterViewSettings* copy)
   setScalarBarVisible(copy->m_ShowScalarBar);
   setAlpha(copy->m_Alpha);
 
-  m_LookupTable->copy(*(copy->m_LookupTable));
+  if(hasUi)
+  {
+    m_LookupTable->copy(*(copy->m_LookupTable));
+  }
 
   emit requiresRender();
 }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
@@ -88,6 +88,12 @@ public:
   VSAbstractFilter* getFilter();
 
   /**
+  * @brief Returns true if the VSFilterViewSettings can be displayed and false otherwise
+  * @return
+  */
+  bool isValid();
+
+  /**
   * @brief Returns true if the filter is displayed in for this view.  Returns false otherwise
   * @return
   */

--- a/SIMPLVtkLib/Visualization/VisualFilters/SourceList.cmake
+++ b/SIMPLVtkLib/Visualization/VisualFilters/SourceList.cmake
@@ -2,10 +2,11 @@
 set(VSVisualFilters
   VSAbstractFilter
   VSClipFilter
+  VSCropFilter
   VSDataSetFilter
   VSMaskFilter
   VSSliceFilter
-  VSCropFilter
+  VSTextFilter
   VSThresholdFilter
 )
 

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h
@@ -198,6 +198,12 @@ public:
   virtual const QString getFilterName() = 0;
 
   /**
+  * @brief Returns the tooltip to use for the filter
+  * @return
+  */
+  virtual QString getToolTip() const = 0;
+
+  /**
   * @brief Save the vtkDataSet output to a file
   * @param fileName
   */

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSClipFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSClipFilter.cpp
@@ -87,6 +87,7 @@ VSClipFilter::VSClipFilter(VSAbstractFilter* parent)
   m_LastBoxInverted = false;
 
   setText(getFilterName());
+  setToolTip(getToolTip());
 }
 
 // -----------------------------------------------------------------------------
@@ -113,6 +114,14 @@ void VSClipFilter::createFilter()
 const QString VSClipFilter::getFilterName()
 {
   return "Clip";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSClipFilter::getToolTip() const
+{
+  return "Clip Filter";
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSClipFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSClipFilter.h
@@ -97,6 +97,12 @@ public:
   const QString getFilterName() override;
 
   /**
+  * @brief Returns the tooltip to use for the filter
+  * @return
+  */
+  virtual QString getToolTip() const override;
+
+  /**
   * @brief Applies the clip filter using a plane with the given values
   * @param origin
   * @param normal

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSCropFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSCropFilter.cpp
@@ -61,6 +61,7 @@ VSCropFilter::VSCropFilter(VSAbstractFilter* parent)
 {
   m_CropAlgorithm = nullptr;
   setText(getFilterName());
+  setToolTip(getToolTip());
 
   for(int i = 0; i < 3; i++)
   {
@@ -119,6 +120,14 @@ void VSCropFilter::apply(int voi[6], int sampleRate[3])
 const QString VSCropFilter::getFilterName()
 {
   return "Crop";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSCropFilter::getToolTip() const
+{
+  return "Crop Filter";
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSCropFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSCropFilter.h
@@ -74,6 +74,12 @@ public:
   const QString getFilterName() override;
 
   /**
+  * @brief Returns the tooltip to use for the filter
+  * @return
+  */
+  virtual QString getToolTip() const override;
+
+  /**
   * @brief Applies the crop filter with the given volume of interest and sample rate
   * @param voi
   * @param sampleRate

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.cpp
@@ -59,6 +59,7 @@ VSDataSetFilter::VSDataSetFilter(SIMPLVtkBridge::WrappedDataContainerPtr wrapped
   createFilter();
 
   setText(wrappedDataContainer->m_Name);
+  setToolTip(getToolTip());
 }
 
 // -----------------------------------------------------------------------------
@@ -134,6 +135,14 @@ void VSDataSetFilter::createFilter()
 //
 // -----------------------------------------------------------------------------
 const QString VSDataSetFilter::getFilterName()
+{
+  return m_WrappedDataContainer->m_Name;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSDataSetFilter::getToolTip() const
 {
   return m_WrappedDataContainer->m_Name;
 }

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.h
@@ -91,6 +91,12 @@ public:
   const QString getFilterName() override;
 
   /**
+  * @brief Returns the tooltip to use for the filter
+  * @return
+  */
+  virtual QString getToolTip() const override;
+
+  /**
   * @brief Returns the output data type for the filter
   * @return
   */

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSMaskFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSMaskFilter.cpp
@@ -63,6 +63,7 @@ VSMaskFilter::VSMaskFilter(VSAbstractFilter* parent)
   m_MaskAlgorithm = nullptr;
   setParentFilter(parent);
   setText(getFilterName());
+  setToolTip(getToolTip());
 }
 
 // -----------------------------------------------------------------------------
@@ -81,6 +82,14 @@ void VSMaskFilter::createFilter()
 const QString VSMaskFilter::getFilterName()
 {
   return "Mask";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSMaskFilter::getToolTip() const
+{
+  return "Mask Filter";
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSMaskFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSMaskFilter.h
@@ -70,6 +70,12 @@ public:
   const QString getFilterName() override;
 
   /**
+  * @brief Returns the tooltip to use for the filter
+  * @return
+  */
+  virtual QString getToolTip() const override;
+
+  /**
   * @brief Applies the mask filter on the specified array
   */
   void apply(QString arrayName);

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSSliceFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSSliceFilter.cpp
@@ -60,6 +60,7 @@ VSSliceFilter::VSSliceFilter(VSAbstractFilter* parent)
   m_SliceAlgorithm = nullptr;
   setParentFilter(parent);
   setText(getFilterName());
+  setToolTip(getToolTip());
 
   m_LastOrigin[0] = 0.0;
   m_LastOrigin[1] = 0.0;
@@ -86,6 +87,14 @@ void VSSliceFilter::createFilter()
 const QString VSSliceFilter::getFilterName()
 {
   return "Slice";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSSliceFilter::getToolTip() const
+{
+  return "Slice Filter";
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSSliceFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSSliceFilter.h
@@ -73,6 +73,12 @@ public:
   const QString getFilterName() override;
 
   /**
+  * @brief Returns the tooltip to use for the filter
+  * @return
+  */
+  virtual QString getToolTip() const override;
+
+  /**
   * @brief Applies the updated values to the algorithm and updates the output
   * @param origin
   * @param normals

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.cpp
@@ -40,9 +40,10 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-VSTextFilter::VSTextFilter(VSAbstractFilter* parent, QString text)
+VSTextFilter::VSTextFilter(VSAbstractFilter* parent, QString text, QString toolTip)
   : VSAbstractFilter()
   , m_Text(text)
+  , m_ToolTip(toolTip)
 {
   setParentFilter(parent);
 
@@ -51,6 +52,7 @@ VSTextFilter::VSTextFilter(VSAbstractFilter* parent, QString text)
   setEditable(false);
   
   setText(getFilterName());
+  setToolTip(toolTip);
   QFont itemFont = font();
   itemFont.setItalic(true);
   setFont(itemFont);
@@ -62,6 +64,14 @@ VSTextFilter::VSTextFilter(VSAbstractFilter* parent, QString text)
 const QString VSTextFilter::getFilterName()
 {
   return m_Text;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSTextFilter::getToolTip() const
+{
+  return m_ToolTip;
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h
@@ -54,13 +54,18 @@ public:
   * @param parent
   * @param text
   */
-  VSTextFilter(VSAbstractFilter* parent, QString text);
+  VSTextFilter(VSAbstractFilter* parent, QString text, QString toolTip);
 
   /**
   * @brief Returns the filter's name
   * @return
   */
   const QString getFilterName() override;
+
+  /**
+  * @brief Returns the filter's tooltip
+  */
+  QString getToolTip() const override;
 
   /**
   * @brief Returns the output port to be used by vtkMappers and subsequent filters
@@ -99,4 +104,5 @@ protected:
 
 private:
   QString m_Text;
+  QString m_ToolTip;
 };

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h
@@ -1,0 +1,102 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h"
+
+/**
+* @class VSTextFilter VSTextFilter.h 
+* SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h
+* @brief This class is used for nothing more than giving its children some sort 
+* of text label.  This filter does not create any data or modify incoming data 
+* in any way.
+*/
+class SIMPLVtkLib_EXPORT VSTextFilter : public VSAbstractFilter
+{
+  Q_OBJECT
+
+public:
+  /**
+  * @brief Constructor
+  * @param parent
+  * @param text
+  */
+  VSTextFilter(VSAbstractFilter* parent, QString text);
+
+  /**
+  * @brief Returns the filter's name
+  * @return
+  */
+  const QString getFilterName() override;
+
+  /**
+  * @brief Returns the output port to be used by vtkMappers and subsequent filters
+  * @return
+  */
+  virtual vtkAlgorithmOutput* getOutputPort() override;
+
+  /**
+  * @brief Returns a smart pointer containing the output data from the filter
+  * @return
+  */
+  virtual VTK_PTR(vtkDataSet) getOutput() override;
+
+  /**
+  * @brief Returns the ouput data type
+  * @return
+  */
+  dataType_t getOutputType() override;
+
+  /**
+  * @brief Returns the required incoming data type
+  */
+  static dataType_t getRequiredInputType();
+
+protected:
+  /**
+  * @brief createFilter() not required by VSTextFilter
+  */
+  void createFilter() override;
+
+  /**
+  * @brief Updates the input port
+  * @param filter
+  */
+  void updateAlgorithmInput(VSAbstractFilter* filter) override;
+
+private:
+  QString m_Text;
+};

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSThresholdFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSThresholdFilter.cpp
@@ -75,6 +75,7 @@ VSThresholdFilter::VSThresholdFilter(VSAbstractFilter* parent)
   m_ThresholdAlgorithm = nullptr;
   setParentFilter(parent);
   setText(getFilterName());
+  setToolTip(getToolTip());
 }
 
 // -----------------------------------------------------------------------------
@@ -96,6 +97,14 @@ void VSThresholdFilter::createFilter()
 const QString VSThresholdFilter::getFilterName()
 {
   return "Threshold";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSThresholdFilter::getToolTip() const
+{
+  return "Threshold Filter";
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSThresholdFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSThresholdFilter.h
@@ -86,6 +86,12 @@ public:
   const QString getFilterName() override;
 
   /**
+  * @brief Returns the tooltip to use for the filter
+  * @return
+  */
+  virtual QString getToolTip() const override;
+
+  /**
   * @brief Applies a threshold over a specified array between a given min and max
   * @param arrayName
   * @param min


### PR DESCRIPTION
Added the VSTextFilter and updated the import process so that importing a file now creates a VSTextFilter with the name of the file set as its text and the file path as its tool-tip.  The VSFilterView now uses a selection model that updates the VSMainWidgetBase's active filter.  When the VSMainWidgetBase's active filter changes, the selection model is updated to reflect that change.

All filters now have their own tool-tip.