### PR TITLE
Feature/Multi-ViewWidgets and vtkWidgets

### DIFF
--- a/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
@@ -59,17 +59,15 @@ VSAbstractViewWidget::VSAbstractViewWidget(const VSAbstractViewWidget& other)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSAbstractViewWidget::copyFilters(VSFilterViewSettings::Container filters)
+void VSAbstractViewWidget::copyFilters(VSFilterViewSettings::Map filters)
 {
   clearFilters();
 
-  int count = filters.size();
-  m_FilterViewSettings.resize(count);
-
-  for(int i = 0; i < count; i++)
+  for(auto iter = filters.begin(); iter != filters.end(); iter++)
   {
-    VSFilterViewSettings* viewSettings = new VSFilterViewSettings(*(filters[i]));
-    m_FilterViewSettings[i] = viewSettings;
+    VSAbstractFilter* filter = iter->first;
+    VSFilterViewSettings* viewSettings = new VSFilterViewSettings(*(iter->second));
+    m_FilterViewSettings[filter] = viewSettings;
 
     connect(viewSettings, SIGNAL(filterAdded(VSAbstractFilter*)), 
       this, SLOT(filterAdded(VSAbstractFilter*)));
@@ -98,9 +96,9 @@ void VSAbstractViewWidget::copyFilters(VSFilterViewSettings::Container filters)
 void VSAbstractViewWidget::clearFilters()
 {
   size_t count = m_FilterViewSettings.size();
-  for(size_t i = 0; i < count; i++)
+  for(auto iter = m_FilterViewSettings.begin(); iter != m_FilterViewSettings.end(); iter++)
   {
-    VSFilterViewSettings* viewSettings = m_FilterViewSettings[i];
+    VSFilterViewSettings* viewSettings = iter->second;
     viewSettings->setVisible(false);
     viewSettings->setScalarBarVisible(false);
     checkFilterViewSetting(viewSettings);
@@ -121,32 +119,7 @@ void VSAbstractViewWidget::filterAdded(VSAbstractFilter* filter)
     return;
   }
 
-  VSFilterViewSettings* viewSettings = new VSFilterViewSettings(filter);
-
-  connect(viewSettings, SIGNAL(visibilityChanged(VSFilterViewSettings*, bool)), 
-    this, SLOT(setFilterVisibility(VSFilterViewSettings*, bool)));
-  connect(viewSettings, SIGNAL(activeArrayIndexChanged(VSFilterViewSettings*, int)), 
-    this, SLOT(setFilterArrayIndex(VSFilterViewSettings*, int)));
-  connect(viewSettings, SIGNAL(activeComponentIndexChanged(VSFilterViewSettings*, int)), 
-    this, SLOT(setFilterComponentIndex(VSFilterViewSettings*, int)));
-  connect(viewSettings, SIGNAL(mapColorsChanged(VSFilterViewSettings*, Qt::CheckState)),
-    this, SLOT(setFilterMapColors(VSFilterViewSettings*, Qt::CheckState)));
-  connect(viewSettings, SIGNAL(showScalarBarChanged(VSFilterViewSettings*, bool)), 
-    this, SLOT(setFilterShowScalarBar(VSFilterViewSettings*, bool)));
-  connect(viewSettings, SIGNAL(requiresRender()), this, SLOT(renderView()));
-
-  m_FilterViewSettings.push_back(viewSettings);
-
-  if(filter->getParentFilter() && filter->getParentFilter()->getOutput())
-  {
-    VSFilterViewSettings* parentSettings = getFilterViewSettings(filter->getParentFilter());
-    if(parentSettings)
-    {
-      viewSettings->copySettings(parentSettings);
-    }
-  }
-
-  checkFilterViewSetting(viewSettings);
+  createFilterViewSettings(filter);
 
   if(dynamic_cast<VSSIMPLDataContainerFilter*>(filter))
   {
@@ -167,22 +140,11 @@ void VSAbstractViewWidget::filterRemoved(VSAbstractFilter* filter)
   VSFilterViewSettings* viewSettings = getFilterViewSettings(filter);
   if(viewSettings)
   {
-    // Stop rendering the filter
-    //viewSettings->setVisible(false);
-    //viewSettings->setScalarBarVisible(false);
-
-    // Remove the FilterViewSetting from the controller
-    int index = getViewSettingsIndex(viewSettings);
-    if(index >= 0)
-    {
-      m_FilterViewSettings.erase(m_FilterViewSettings.begin() + index);
-    }
-
-    // Delete the FilterViewSetting
+    setFilterVisibility(viewSettings, false);
     viewSettings->deleteLater();
   }
 
-  setFilterVisibility(viewSettings, false);
+  m_FilterViewSettings.erase(filter);
 }
 
 // -----------------------------------------------------------------------------
@@ -224,29 +186,26 @@ void VSAbstractViewWidget::setActiveFilterSettings(VSFilterViewSettings* setting
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-VSFilterViewSettings* VSAbstractViewWidget::getFilterViewSettings(VSAbstractFilter* filter) const
+VSFilterViewSettings* VSAbstractViewWidget::getFilterViewSettings(VSAbstractFilter* filter)
 {
   if(nullptr == filter)
   {
     return nullptr;
   }
 
-  size_t count = m_FilterViewSettings.size();
-  for(size_t i = 0; i < count; i++)
+  VSFilterViewSettings* settings = m_FilterViewSettings[filter];
+  if(nullptr == settings)
   {
-    if(m_FilterViewSettings[i]->getFilter() == filter)
-    {
-      return m_FilterViewSettings[i];
-    }
+    settings = createFilterViewSettings(filter);
   }
 
-  return nullptr;
+  return settings;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-VSFilterViewSettings::Container VSAbstractViewWidget::getAllFilterViewSettings() const
+VSFilterViewSettings::Map VSAbstractViewWidget::getAllFilterViewSettings() const
 {
   return m_FilterViewSettings;
 }
@@ -256,13 +215,59 @@ VSFilterViewSettings::Container VSAbstractViewWidget::getAllFilterViewSettings()
 // -----------------------------------------------------------------------------
 int VSAbstractViewWidget::getViewSettingsIndex(VSFilterViewSettings* settings)
 {
-  auto iter = std::find(m_FilterViewSettings.begin(), m_FilterViewSettings.end(), settings);
+  auto iter = m_FilterViewSettings.find(settings->getFilter());
   if(iter == m_FilterViewSettings.end())
   {
     return -1;
   }
 
   return std::distance(m_FilterViewSettings.begin(), iter);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+VSFilterViewSettings* VSAbstractViewWidget::createFilterViewSettings(VSAbstractFilter* filter)
+{
+  if(nullptr == filter)
+  {
+    return nullptr;
+  }
+
+  // Do not overwrite filter view settings that already exist
+  if(nullptr != m_FilterViewSettings[filter])
+  {
+    return m_FilterViewSettings[filter];
+  }
+
+  VSFilterViewSettings* viewSettings = new VSFilterViewSettings(filter);
+
+  connect(viewSettings, SIGNAL(visibilityChanged(VSFilterViewSettings*, bool)),
+    this, SLOT(setFilterVisibility(VSFilterViewSettings*, bool)));
+  connect(viewSettings, SIGNAL(activeArrayIndexChanged(VSFilterViewSettings*, int)),
+    this, SLOT(setFilterArrayIndex(VSFilterViewSettings*, int)));
+  connect(viewSettings, SIGNAL(activeComponentIndexChanged(VSFilterViewSettings*, int)),
+    this, SLOT(setFilterComponentIndex(VSFilterViewSettings*, int)));
+  connect(viewSettings, SIGNAL(mapColorsChanged(VSFilterViewSettings*, Qt::CheckState)),
+    this, SLOT(setFilterMapColors(VSFilterViewSettings*, Qt::CheckState)));
+  connect(viewSettings, SIGNAL(showScalarBarChanged(VSFilterViewSettings*, bool)),
+    this, SLOT(setFilterShowScalarBar(VSFilterViewSettings*, bool)));
+  connect(viewSettings, SIGNAL(requiresRender()), this, SLOT(renderView()));
+
+  m_FilterViewSettings[filter] = viewSettings;
+
+  if(filter->getParentFilter() && filter->getParentFilter()->getOutput())
+  {
+    VSFilterViewSettings* parentSettings = getFilterViewSettings(filter->getParentFilter());
+    if(parentSettings)
+    {
+      viewSettings->copySettings(parentSettings);
+    }
+  }
+
+  checkFilterViewSetting(viewSettings);
+
+  return viewSettings;
 }
 
 // -----------------------------------------------------------------------------
@@ -616,11 +621,10 @@ void VSAbstractViewWidget::setController(VSController* controller)
 
   QVector<VSAbstractFilter*> filters = controller->getAllFilters();
   int count = filters.size();
-  m_FilterViewSettings.resize(count);
-  for(size_t i = 0; i < count; i++)
+  for(VSAbstractFilter* filter : filters)
   {
-    VSFilterViewSettings* viewSettings = new VSFilterViewSettings(filters[i]);
-    m_FilterViewSettings[i] = viewSettings;
+    VSFilterViewSettings* viewSettings = new VSFilterViewSettings(filter);
+    m_FilterViewSettings[filter] = viewSettings;
 
     connect(viewSettings, SIGNAL(visibilityChanged(VSFilterViewSettings*, bool)), 
       this, SLOT(setFilterVisibility(VSFilterViewSettings*, bool)));
@@ -633,11 +637,8 @@ void VSAbstractViewWidget::setController(VSController* controller)
     connect(viewSettings, SIGNAL(showScalarBarChanged(VSFilterViewSettings*, bool)), 
       this, SLOT(setFilterShowScalarBar(VSFilterViewSettings*, bool)));
     connect(viewSettings, SIGNAL(requiresRender()), this, SLOT(renderView()));
-  }
 
-  // Check filter and scalar bar visibility
-  for(VSFilterViewSettings* setting : m_FilterViewSettings)
-  {
-    checkFilterViewSetting(setting);
+    // Check filter and scalar bar visibility
+    checkFilterViewSetting(viewSettings);
   }
 }

--- a/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.h
+++ b/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.h
@@ -84,13 +84,13 @@ public:
   * @brief Returns the VSFilterViewSettings for the given filter.
   * @param filter
   */
-  VSFilterViewSettings* getFilterViewSettings(VSAbstractFilter* filter) const;
+  VSFilterViewSettings* getFilterViewSettings(VSAbstractFilter* filter);
 
   /**
   * @brief Returns the container of VSFilterViewSettings
   * @return
   */
-  VSFilterViewSettings::Container getAllFilterViewSettings() const;
+  VSFilterViewSettings::Map getAllFilterViewSettings() const;
 
   /**
   * @brief Returns the VSController used by this widget
@@ -246,7 +246,14 @@ protected:
   * @brief Copies the filters and sets up connections
   * @param filters
   */
-  void copyFilters(VSFilterViewSettings::Container filters);
+  void copyFilters(VSFilterViewSettings::Map filters);
+
+  /**
+  * @brief Creates a new VSFilterViewSetting for the given filter.
+  * @param filter
+  * @return
+  */
+  VSFilterViewSettings* createFilterViewSettings(VSAbstractFilter* filter);
 
   /**
   * @brief Returns the index of the given VSFilterViewSetting
@@ -274,6 +281,6 @@ protected:
 
 private:
   VSFilterViewSettings* m_ActiveFilterSettings = nullptr;
-  VSFilterViewSettings::Container m_FilterViewSettings;
+  VSFilterViewSettings::Map m_FilterViewSettings;
   VSController* m_Controller = nullptr;
 };

--- a/SIMPLVtkLib/QtWidgets/VSFilterView.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterView.cpp
@@ -53,6 +53,7 @@ VSFilterView::VSFilterView(QWidget* parent)
 void VSFilterView::setupGui()
 {
   setHeaderHidden(true);
+  setSelectionMode(QAbstractItemView::SingleSelection);
 }
 
 // -----------------------------------------------------------------------------
@@ -190,18 +191,6 @@ void VSFilterView::setCurrentItem(const QModelIndex& current, const QModelIndex&
 void VSFilterView::connectSlots()
 {
   connect(this, SIGNAL(clicked(const QModelIndex&)), this, SLOT(itemClicked(const QModelIndex&)));
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void VSFilterView::mousePressEvent(QMouseEvent* event)
-{
-  clearSelection();
-
-  emit filterClicked(nullptr);
-
-  QTreeView::mousePressEvent(event);
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/QtWidgets/VSFilterView.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterView.cpp
@@ -142,6 +142,12 @@ void VSFilterView::setActiveFilter(VSAbstractFilter* filter, VSAbstractFilterWid
   {
     return;
   }
+  if(nullptr == filter)
+  {
+    selectionModel()->clear();
+    return;
+  }
+
 
   QModelIndex currentIndex = selectionModel()->currentIndex();
   QModelIndex newIndex = filterModel->getIndexFromFilter(filter);

--- a/SIMPLVtkLib/QtWidgets/VSFilterView.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterView.h
@@ -128,12 +128,6 @@ protected:
   */
   VSAbstractFilter* getFilterFromIndex(const QModelIndex& index);
 
-  /**
-   * @brief mousePressEvent
-   * @param event
-   */
-  void mousePressEvent(QMouseEvent* event) override;
-
 private:
   VSController* m_Controller = nullptr;
   VSAbstractViewWidget* m_ViewWidget = nullptr;

--- a/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
@@ -195,7 +195,20 @@ void VSInfoWidget::setFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* f
 
   updateFilterInfo();
   updateViewSettingInfo();
-  adjustSize();
+
+  // Update widget size
+  QSize preferredSize = sizeHint();
+  int newWidth;
+  if(parentWidget())
+  {
+    newWidth = std::min(width(), parentWidget()->width());
+  }
+  else
+  {
+    newWidth = width();
+  }
+  preferredSize.setWidth(width());
+  resize(preferredSize);
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
@@ -185,7 +185,7 @@ void VSInfoWidget::setFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* f
   }
   m_Internals->applyBtn->setEnabled(viewSettingsValid);
   m_Internals->resetBtn->setEnabled(viewSettingsValid);
-  m_Internals->deleteBtn->setEnabled(viewSettingsValid);
+  m_Internals->deleteBtn->setEnabled(filterExists);
 
   if (m_FilterWidget != nullptr)
   {

--- a/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
@@ -155,8 +155,8 @@ void VSInfoWidget::setFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* f
 {
   if (m_FilterWidget != nullptr)
   {
-    m_FilterWidget->setDrawingEnabled(false);
     m_Internals->gridLayout_4->removeWidget(m_FilterWidget);
+    m_FilterWidget->hide();
     m_FilterWidget = nullptr;
   }
 
@@ -190,7 +190,7 @@ void VSInfoWidget::setFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* f
   if (m_FilterWidget != nullptr)
   {
     m_Internals->gridLayout_4->addWidget(m_FilterWidget);
-    m_FilterWidget->setDrawingEnabled(true);
+    m_FilterWidget->show();
   }
 
   updateFilterInfo();
@@ -248,11 +248,6 @@ void VSInfoWidget::setViewWidget(VSAbstractViewWidget* viewWidget)
   else
   {
     connectFilterViewSettings(nullptr);
-  }
-
-  if (m_FilterWidget)
-  {
-    m_FilterWidget->setDrawingEnabled(true);
   }
 
   updateViewSettingInfo();

--- a/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
@@ -245,6 +245,8 @@ void VSMainWidgetBase::filterAdded(VSAbstractFilter* filter)
   {
     m_FilterToFilterWidgetMap.insert(filter, fw);
   }
+
+  setCurrentFilter(filter);
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
@@ -123,7 +123,7 @@ void VSMainWidgetBase::setFilterView(VSFilterView* view)
   if(m_FilterView)
   {
     disconnect(m_FilterView, SIGNAL(filterClicked(VSAbstractFilter*)));
-    disconnect(this, SIGNAL(changedActiveView(VSAbstractViewWidget*)), view, SLOT(changeViewWidget(VSAbstractViewWidget*)));
+    disconnect(this, SIGNAL(changedActiveView(VSAbstractViewWidget*)), view, SLOT(setViewWidget(VSAbstractViewWidget*)));
     disconnect(this, SIGNAL(changedActiveFilter(VSAbstractFilter*, VSAbstractFilterWidget*)),
       view, SLOT(setActiveFilter(VSAbstractFilter*, VSAbstractFilterWidget*)));
   }

--- a/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
@@ -298,7 +298,6 @@ void VSMainWidgetBase::setActiveView(VSAbstractViewWidget* viewWidget)
     VSAbstractFilterWidget* fw;
     foreach(fw, m_FilterToFilterWidgetMap.values())
     {
-      fw->setDrawingEnabled(false);
       fw->setInteractor(getActiveViewWidget()->getVisualizationWidget()->GetInteractor());
     }
   }
@@ -335,7 +334,7 @@ void VSMainWidgetBase::setCurrentFilter(VSAbstractFilter* filter)
   VSAbstractFilterWidget* filterWidget = m_FilterToFilterWidgetMap.value(m_CurrentFilter);
   if(filterWidget)
   {
-    filterWidget->setDrawingEnabled(false);
+    filterWidget->setRenderingEnabled(false);
   }
 
   m_CurrentFilter = filter;
@@ -343,7 +342,7 @@ void VSMainWidgetBase::setCurrentFilter(VSAbstractFilter* filter)
 
   if(filterWidget)
   {
-    filterWidget->setDrawingEnabled(true);
+    filterWidget->setRenderingEnabled(true);
   }
 
   emit changedActiveFilter(m_CurrentFilter, filterWidget);

--- a/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
@@ -263,6 +263,12 @@ void VSMainWidgetBase::filterRemoved(VSAbstractFilter* filter)
 // -----------------------------------------------------------------------------
 void VSMainWidgetBase::setActiveView(VSAbstractViewWidget* viewWidget)
 {
+  // Do nothing if the active view is not changed
+  if(viewWidget == m_ActiveViewWidget)
+  {
+    return;
+  }
+
   // Disconnect the old active view widget
   if(m_ActiveViewWidget)
   {

--- a/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
@@ -332,8 +332,19 @@ void VSMainWidgetBase::activeViewClosed()
 // -----------------------------------------------------------------------------
 void VSMainWidgetBase::setCurrentFilter(VSAbstractFilter* filter)
 {
+  VSAbstractFilterWidget* filterWidget = m_FilterToFilterWidgetMap.value(m_CurrentFilter);
+  if(filterWidget)
+  {
+    filterWidget->setDrawingEnabled(false);
+  }
+
   m_CurrentFilter = filter;
-  VSAbstractFilterWidget* filterWidget = m_FilterToFilterWidgetMap.value(filter);
+  filterWidget = m_FilterToFilterWidgetMap.value(filter);
+
+  if(filterWidget)
+  {
+    filterWidget->setDrawingEnabled(true);
+  }
 
   emit changedActiveFilter(m_CurrentFilter, filterWidget);
 }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterModel.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterModel.cpp
@@ -158,10 +158,11 @@ QVector<VSAbstractFilter*> VSFilterModel::getAllFilters()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSFilterModel::updateModelForView(VSFilterViewSettings::Container viewSettings)
+void VSFilterModel::updateModelForView(VSFilterViewSettings::Map viewSettings)
 {
-  for(VSFilterViewSettings* settings : viewSettings)
+  for(auto iter = viewSettings.begin(); iter != viewSettings.end(); iter++)
   {
+    VSFilterViewSettings* settings = iter->second;
     VSAbstractFilter* filter = settings->getFilter();
     filter->setCheckState(settings->getVisible() ? Qt::Checked : Qt::Unchecked);
   }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterModel.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterModel.h
@@ -101,8 +101,8 @@ signals:
 public slots:
   /**
   * @brief Updates the model to reflect the view settings found in a given view controller
-  * @param viewController
+  * @param viewSettings
   */
-  void updateModelForView(VSFilterViewSettings::Container viewSettings);
+  void updateModelForView(VSFilterViewSettings::Map viewSettings);
 };
 

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <vector>
+#include <map>
 
 #include <QtCore/QObject>
 
@@ -62,7 +63,7 @@ class SIMPLVtkLib_EXPORT VSFilterViewSettings : public QObject
   Q_OBJECT
 
 public:
-  using Container = std::vector<VSFilterViewSettings*>;
+  using Map = std::map<VSAbstractFilter*, VSFilterViewSettings*>;
 
   /**
   * @brief Constructor

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSAbstractFilterWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSAbstractFilterWidget.cpp
@@ -77,7 +77,15 @@ void VSAbstractFilterWidget::setInteractor(QVTKInteractor* interactor)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSAbstractFilterWidget::setDrawingEnabled(bool enabled)
+void VSAbstractFilterWidget::setRenderingEnabled(bool enabled)
 {
-  Q_UNUSED(enabled)
+  m_RenderingEnabled = enabled;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+bool VSAbstractFilterWidget::getRenderingEnabled()
+{
+  return m_RenderingEnabled;
 }

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSAbstractFilterWidget.h
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSAbstractFilterWidget.h
@@ -77,10 +77,15 @@ public:
   virtual void reset();
 
   /**
-   * @brief Sets whether the filter widget should render drawings in the visualization window
+   * @brief Sets whether the filter widget should render its vtkWidget in the visualization window
    * @param enabled
    */
-  virtual void setDrawingEnabled(bool enabled);
+  virtual void setRenderingEnabled(bool enabled);
+
+  /**
+  * @brief Returns whether the filter widget is rendered
+  */
+  bool getRenderingEnabled();
 
   /**
    * @brief setInteractor
@@ -95,7 +100,7 @@ protected:
   VSAbstractFilterWidget(QWidget *parent = nullptr);
 
 private:
-
+  bool m_RenderingEnabled = true;
 };
 
 #ifdef __clang__

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSClipFilterWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSClipFilterWidget.cpp
@@ -199,6 +199,9 @@ void VSClipFilterWidget::reset()
 // -----------------------------------------------------------------------------
 void VSClipFilterWidget::setInteractor(QVTKInteractor* interactor)
 {
+  bool rendered = getRenderingEnabled();
+  setRenderingEnabled(false);
+
   if (m_PlaneWidget)
   {
     m_PlaneWidget->setInteractor(interactor);
@@ -208,13 +211,17 @@ void VSClipFilterWidget::setInteractor(QVTKInteractor* interactor)
   {
     m_BoxWidget->setInteractor(interactor);
   }
+
+  setRenderingEnabled(rendered);
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSClipFilterWidget::setDrawingEnabled(bool enabled)
+void VSClipFilterWidget::setRenderingEnabled(bool enabled)
 {
+  VSAbstractFilterWidget::setRenderingEnabled(enabled);
+
   if (m_Internals->clipTypeComboBox->currentText() == VSClipFilter::PlaneClipTypeString)
   {
     (enabled) ? m_PlaneWidget->enable() : m_PlaneWidget->disable();

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSClipFilterWidget.h
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSClipFilterWidget.h
@@ -99,7 +99,7 @@ public:
    * @brief Sets whether the filter widget should render drawings in the visualization window
    * @param enabled
    */
-  void setDrawingEnabled(bool enabled) override;
+  void setRenderingEnabled(bool enabled) override;
 
   /**
    * @brief setInteractor

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.cpp
@@ -121,5 +121,12 @@ void VSSliceFilterWidget::apply()
 // -----------------------------------------------------------------------------
 void VSSliceFilterWidget::reset()
 {
+}
 
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSSliceFilterWidget::setDrawingEnabled(bool enabled)
+{
+  (enabled) ? m_SliceWidget->enable() : m_SliceWidget->disable();
 }

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.cpp
@@ -126,7 +126,21 @@ void VSSliceFilterWidget::reset()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSSliceFilterWidget::setDrawingEnabled(bool enabled)
+void VSSliceFilterWidget::setRenderingEnabled(bool enabled)
 {
+  VSAbstractFilterWidget::setRenderingEnabled(enabled);
+
   (enabled) ? m_SliceWidget->enable() : m_SliceWidget->disable();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSSliceFilterWidget::setInteractor(QVTKInteractor* interactor)
+{
+  bool rendered = getRenderingEnabled();
+
+  setRenderingEnabled(false);
+  m_SliceWidget->setInteractor(interactor);
+  setRenderingEnabled(rendered);
 }

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.h
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.h
@@ -89,6 +89,12 @@ public:
    */
   void reset() override;
 
+  /**
+  * @brief Sets whether the filter widget should render drawings in the visualization window
+  * @param enabled
+  */
+  void setDrawingEnabled(bool enabled) override;
+
 private:
   class vsInternals;
   vsInternals*                    m_Internals;

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.h
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.h
@@ -93,7 +93,13 @@ public:
   * @brief Sets whether the filter widget should render drawings in the visualization window
   * @param enabled
   */
-  void setDrawingEnabled(bool enabled) override;
+  void setRenderingEnabled(bool enabled) override;
+
+  /**
+  * @brief setInteractor
+  * @param interactor
+  */
+  void setInteractor(QVTKInteractor* interactor) override;
 
 private:
   class vsInternals;


### PR DESCRIPTION
* Forced SingleSelection mode for VSFilterView and removed the clearSelection() on mouse click.

* Fixed a bug that caused any attempt to manipulate a vtkWidget created by a filter widget to render the active visualization widget inoperable.

* Fixed a bug that caused adding a filter to not set it to the active filter.  This had caused the expected action when applying the filter to not match up with the result.

* Enabling or disabling the rendering of filter widgets was moved to VSMainWidgetBase.  As a VSInfoWidget is not required, it should not be in charge of directly changing the rendering of filter widgets to the active visualization widget.  In addition, by moving this to VSMainWidgetBase, classes that inherit from VSMainWidgetBase can change this behavior as required.

* Fixed a bug that caused the VSSliceFilter to not render a vtkPlane when setting it as the active filter.

* Fixed a bug where Qt signals could cause a VSAbstractViewWidget's VSFilterViewSettings to be null for a new filter based on the order that slots were called.  Requesting VSFilterViewSettings for a filter when no VSFilterViewSettings exist for it yet causes one to be created based on its parent filter settings.  If the view settings are created in this way before VSAbstractViewWidget's slot to add the filter is called, the generated VSFilterViewSettings are left as they are without being overwritten by the default values.

* Fixed a bug where top-level VSTextFilters could not be deleted through the VSInfoWidget because the filter did not output a vtkDataSet.  The delete button in VSInfoWidget is now enabled or disabled based on if the active filter is null rather than if the filter's VSFilterViewSettings are valid.

* Specifically set VSFilterView to clear the selection if the current filter is set to null.

* Fixed a bug that caused the VSInfoWidget to expand horizontally outside the bounds of its parent.