### PR TITLE
Updated visibility settings when deleting filters

### DIFF
--- a/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
@@ -163,7 +163,7 @@ void VSAbstractViewWidget::checkFilterViewSetting(VSFilterViewSettings* setting)
 
   setting->getScalarBarWidget()->SetInteractor(getVisualizationWidget()->GetInteractor());
 
-  setFilterVisibility(setting, setting->getVisible());
+  setFilterVisibility(setting, setting->isVisible());
   setFilterShowScalarBar(setting, setting->isScalarBarVisible());
 }
 
@@ -341,7 +341,7 @@ void VSAbstractViewWidget::setFilterMapColors(VSFilterViewSettings* viewSettings
 // -----------------------------------------------------------------------------
 void VSAbstractViewWidget::setFilterShowScalarBar(VSFilterViewSettings* viewSettings, bool showScalarBar)
 {
-  if(viewSettings->getVisible())
+  if(viewSettings->isVisible())
   {
     if(viewSettings->isScalarBarVisible())
     {

--- a/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
@@ -362,8 +362,16 @@ void VSMainWidgetBase::deleteFilter(VSAbstractFilter* filter)
   for(VSAbstractViewWidget* widget : viewWidgets)
   {
     VSFilterViewSettings* viewSettings = widget->getFilterViewSettings(filter);
+    bool visible = viewSettings->isVisible();
     viewSettings->setVisible(false);
     viewSettings->setScalarBarVisible(false);
+
+    VSFilterViewSettings* parentSettings = widget->getFilterViewSettings(filter->getParentFilter());
+    if(parentSettings)
+    {
+      bool parentVisible = parentSettings->isVisible();
+      parentSettings->setVisible(visible || parentVisible);
+    }
   }
 
   QVector<VSAbstractFilter*> childFilters = filter->getChildren();

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterModel.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterModel.cpp
@@ -164,6 +164,6 @@ void VSFilterModel::updateModelForView(VSFilterViewSettings::Map viewSettings)
   {
     VSFilterViewSettings* settings = iter->second;
     VSAbstractFilter* filter = settings->getFilter();
-    filter->setCheckState(settings->getVisible() ? Qt::Checked : Qt::Unchecked);
+    filter->setCheckState(settings->isVisible() ? Qt::Checked : Qt::Unchecked);
   }
 }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -102,7 +102,7 @@ bool VSFilterViewSettings::isValid()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool VSFilterViewSettings::getVisible()
+bool VSFilterViewSettings::isVisible()
 {
   return m_ShowFilter;
 }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
@@ -98,7 +98,7 @@ public:
   * @brief Returns true if the filter is displayed in for this view.  Returns false otherwise
   * @return
   */
-  bool getVisible();
+  bool isVisible();
 
   /**
   * @brief Returns the active array index used to render the filter


### PR DESCRIPTION
* Changed VSMainWidgetBase to make a filter visible when it's child is deleted if either of them are visible.

* Renamed the getVisible() method in VSFilterViewSettings to isVisible()