### PR TITLE
Feature/plane rep

### DIFF
--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSClipFilterWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSClipFilterWidget.cpp
@@ -153,6 +153,7 @@ void VSClipFilterWidget::apply()
     double origin[3];
     m_PlaneWidget->getNormals(normals);
     m_PlaneWidget->getOrigin(origin);
+    m_PlaneWidget->drawPlaneOff();
 
     m_ClipFilter->apply(origin, normals, m_Internals->insideOutCheckBox->isChecked());
   }
@@ -182,6 +183,7 @@ void VSClipFilterWidget::reset()
     m_PlaneWidget->setOrigin(origin);
     m_Internals->insideOutCheckBox->setChecked(inverted);
     m_PlaneWidget->updatePlaneWidget();
+    m_PlaneWidget->drawPlaneOff();
   }
   else if (m_Internals->clipTypeComboBox->currentText() == VSClipFilter::BoxClipTypeString)
   {

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/VSSliceFilterWidget.cpp
@@ -112,6 +112,7 @@ void VSSliceFilterWidget::apply()
 
   m_SliceWidget->getOrigin(origin);
   m_SliceWidget->getNormals(normals);
+  m_SliceWidget->drawPlaneOff();
 
   m_SliceFilter->apply(origin, normals);
 }
@@ -121,6 +122,13 @@ void VSSliceFilterWidget::apply()
 // -----------------------------------------------------------------------------
 void VSSliceFilterWidget::reset()
 {
+  double* origin = m_SliceFilter->getLastOrigin();
+  double* normals = m_SliceFilter->getLastNormal();
+
+  m_SliceWidget->setNormals(normals);
+  m_SliceWidget->setOrigin(origin);
+  m_SliceWidget->updatePlaneWidget();
+  m_SliceWidget->drawPlaneOff();
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VtkWidgets/VSAbstractWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VtkWidgets/VSAbstractWidget.cpp
@@ -42,21 +42,14 @@
 // -----------------------------------------------------------------------------
 VSAbstractWidget::VSAbstractWidget(QWidget* parent, double bounds[6], vtkRenderWindowInteractor* iren)
 : QWidget(parent)
-, m_renderWindowInteractor(iren)
+, m_RenderWindowInteractor(iren)
 {
   setBounds(bounds);
 
   for(int i = 0; i < 3; i++)
   {
-    origin[i] = (bounds[i * 2] + bounds[i * 2 + 1]) / 2.0;
+    m_Origin[i] = (bounds[i * 2] + bounds[i * 2 + 1]) / 2.0;
   }
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-VSAbstractWidget::~VSAbstractWidget()
-{
 }
 
 // -----------------------------------------------------------------------------
@@ -66,8 +59,16 @@ void VSAbstractWidget::getBounds(double bounds[6])
 {
   for(int i = 0; i < 6; i++)
   {
-    bounds[i] = this->bounds[i];
+    bounds[i] = this->m_Bounds[i];
   }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+double* VSAbstractWidget::getBounds()
+{
+  return m_Bounds;
 }
 
 // -----------------------------------------------------------------------------
@@ -77,8 +78,16 @@ void VSAbstractWidget::getOrigin(double origin[3])
 {
   for(int i = 0; i < 3; i++)
   {
-    origin[i] = this->origin[i];
+    origin[i] = this->m_Origin[i];
   }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+double* VSAbstractWidget::getOrigin()
+{
+  return m_Origin;
 }
 
 // -----------------------------------------------------------------------------
@@ -92,8 +101,8 @@ void VSAbstractWidget::setBounds(double bounds[6])
     if(bounds[i * 2 + 1] - bounds[i * 2] < MIN_SIZE)
       offset = (MIN_SIZE - (bounds[i * 2 + 1] - bounds[i * 2])) / 2.0;
 
-    this->bounds[i * 2] = bounds[i * 2] - offset;
-    this->bounds[i * 2 + 1] = bounds[i * 2 + 1] + offset;
+    this->m_Bounds[i * 2] = bounds[i * 2] - offset;
+    this->m_Bounds[i * 2 + 1] = bounds[i * 2 + 1] + offset;
   }
 
   updateBounds();
@@ -106,7 +115,7 @@ void VSAbstractWidget::setOrigin(double origin[3])
 {
   for(int i = 0; i < 3; i++)
   {
-    this->origin[i] = origin[i];
+    this->m_Origin[i] = origin[i];
   }
 
   updateOrigin();
@@ -117,9 +126,9 @@ void VSAbstractWidget::setOrigin(double origin[3])
 // -----------------------------------------------------------------------------
 void VSAbstractWidget::setOrigin(double x, double y, double z)
 {
-  origin[0] = x;
-  origin[1] = y;
-  origin[2] = z;
+  m_Origin[0] = x;
+  m_Origin[1] = y;
+  m_Origin[2] = z;
 
   updateOrigin();
 }
@@ -127,9 +136,17 @@ void VSAbstractWidget::setOrigin(double x, double y, double z)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+vtkRenderWindowInteractor* VSAbstractWidget::getInteractor()
+{
+  return m_RenderWindowInteractor;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void VSAbstractWidget::setInteractor(vtkRenderWindowInteractor* interactor)
 {
-  m_renderWindowInteractor = interactor;
+  m_RenderWindowInteractor = interactor;
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VtkWidgets/VSAbstractWidget.h
+++ b/SIMPLVtkLib/Visualization/VtkWidgets/VSAbstractWidget.h
@@ -48,41 +48,113 @@
 class vtkRenderWindowInteractor;
 class vtkImplicitFunction;
 
+/**
+* @class VSAbstractWidget VSAbstractWidget.h 
+* SIMPLVtkLib/Visualization/VtkWidgets/VSAbstractWidget.h
+* @brief This is the base class for combined Qt/vtk widget representations.
+* Subclasses will be displayed in the GUI as a subclass of QWidget and may 
+* display a representation of the stored data through a vtkWidget in the the 
+* given vtkRenderWindowInteractor.
+*/
 class SIMPLVtkLib_EXPORT VSAbstractWidget : public QWidget
 {
   Q_OBJECT
 
 public:
+  /**
+  * @brief Constructor
+  * @param parent
+  * @param bounds
+  * @param iren
+  */
   VSAbstractWidget(QWidget* parent, double bounds[6], vtkRenderWindowInteractor* iren);
-  ~VSAbstractWidget();
 
+  /**
+  * @brief Copies the vtkWidget bounds
+  * @param bounds
+  */
   void getBounds(double bounds[6]);
-  void getOrigin(double origin[3]);
 
+  /**
+  * @brief Returns the vtkWidget bounds
+  * @return
+  */
+  double* getBounds();
+
+  /**
+  * @brief Copies the vtkWidget origin
+  * @param origin
+  */
+  void getOrigin(double origin[3]);
+  
+  /**
+  * @brief Returns the vtkWidget origin
+  * @return
+  */
+  double* getOrigin();
+
+  /**
+  * @brief Sets the bounds
+  * @param bounds
+  */
   void setBounds(double bounds[6]);
+
+  /**
+  * @brief Sets the origin
+  * @param origin
+  */
   virtual void setOrigin(double origin[3]);
+
+  /**
+  * @brief Sets the origin
+  * @param x
+  * @param y
+  * @param z
+  */
   virtual void setOrigin(double x, double y, double z);
 
+  /**
+  * @brief Enables the vtkWidget
+  */
   virtual void enable() = 0;
+
+  /**
+  * @brief Disables the vtkWidget
+  */
   virtual void disable() = 0;
 
+  /**
+  * @brief Returns the vtkRenderWindowInteractor 
+  * @return
+  */
+  vtkRenderWindowInteractor* getInteractor();
+
+  /**
+  * @brief Sets the vtkRenderWindowInteractor to render to
+  * @param interactor
+  */
   virtual void setInteractor(vtkRenderWindowInteractor* interactor);
 
 signals:
   void modified();
 
 protected:
+  /**
+  * @brief Updates the widget bounds
+  */
   virtual void updateBounds();
-  virtual void updateOrigin();
 
-  double bounds[6];
-  double origin[3];
+  /**
+  * @brief Updates the widget origin
+  */
+  virtual void updateOrigin();
 
   const double MIN_SIZE = 6.0;
 
-  vtkRenderWindowInteractor* m_renderWindowInteractor;
-
 private:
+  vtkRenderWindowInteractor * m_RenderWindowInteractor;
+  double m_Bounds[6];
+  double m_Origin[3];
 };
 
 #ifdef __clang__

--- a/SIMPLVtkLib/Visualization/VtkWidgets/VSBoxWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VtkWidgets/VSBoxWidget.cpp
@@ -201,7 +201,7 @@ void VSBoxWidget::setRotation(double x, double y, double z)
 void VSBoxWidget::updateBounds()
 {
   m_BoxWidget->EnabledOff();
-  m_BoxWidget->GetRepresentation()->PlaceWidget(bounds);
+  m_BoxWidget->GetRepresentation()->PlaceWidget(getBounds());
   m_BoxWidget->EnabledOn();
 }
 
@@ -219,9 +219,9 @@ void VSBoxWidget::enable()
 {
   m_BoxWidget->EnabledOn();
 
-  if (m_renderWindowInteractor)
+  if(getInteractor())
   {
-    m_renderWindowInteractor->Render();
+    getInteractor()->Render();
   }
 }
 
@@ -232,9 +232,9 @@ void VSBoxWidget::disable()
 {
   m_BoxWidget->EnabledOff();
 
-  if (m_renderWindowInteractor)
+  if(getInteractor())
   {
-    m_renderWindowInteractor->Render();
+    getInteractor()->Render();
   }
 }
 
@@ -245,6 +245,7 @@ void VSBoxWidget::updateSpinBoxes()
 {
   double scale[3];
   double rotation[3];
+  double origin[3];
 
   vtkMatrix4x4* matrix = m_ViewTransform->GetMatrix();
 
@@ -270,6 +271,7 @@ void VSBoxWidget::updateSpinBoxes()
 // -----------------------------------------------------------------------------
 void VSBoxWidget::spinBoxValueChanged()
 {
+  double origin[3];
   origin[0] = translationXSpinBox->value();
   origin[1] = translationYSpinBox->value();
   origin[2] = translationZSpinBox->value();
@@ -298,7 +300,7 @@ void VSBoxWidget::updateBoxWidget()
   m_ViewTransform->Update();
   m_BoxRep->SetTransform(m_ViewTransform);
 
-  m_renderWindowInteractor->Render();
+  getInteractor()->Render();
 }
 
 // -----------------------------------------------------------------------------
@@ -376,6 +378,6 @@ void VSBoxWidget::setValues(double position[3], double rotation[3], double scale
 // -----------------------------------------------------------------------------
 void VSBoxWidget::setInteractor(vtkRenderWindowInteractor* interactor)
 {
-  m_renderWindowInteractor = interactor;
+  VSAbstractWidget::setInteractor(interactor);
   m_BoxWidget->SetInteractor(interactor);
 }

--- a/SIMPLVtkLib/Visualization/VtkWidgets/VSBoxWidget.h
+++ b/SIMPLVtkLib/Visualization/VtkWidgets/VSBoxWidget.h
@@ -170,6 +170,10 @@ public:
   */
   void updateBoxWidget();
 
+  /**
+  * @brief Sets the current vtkRenderWindowInteractor
+  * @param interactor
+  */
   void setInteractor(vtkRenderWindowInteractor* interactor) override;
 
 public slots:

--- a/SIMPLVtkLib/Visualization/VtkWidgets/VSPlaneWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VtkWidgets/VSPlaneWidget.cpp
@@ -158,6 +158,8 @@ void VSPlaneWidget::setNormals(double normals[3])
   normalXSpinBox->setValue(normals[0]);
   normalYSpinBox->setValue(normals[1]);
   normalZSpinBox->setValue(normals[2]);
+
+  drawPlaneOn();
 }
 
 // -----------------------------------------------------------------------------
@@ -181,6 +183,8 @@ void VSPlaneWidget::setOrigin(double origin[3])
   originXSpinBox->setValue(origin[0]);
   originYSpinBox->setValue(origin[1]);
   originZSpinBox->setValue(origin[2]);
+
+  drawPlaneOn();
 }
 
 // -----------------------------------------------------------------------------
@@ -230,9 +234,35 @@ void VSPlaneWidget::disable()
 {
   m_PlaneWidget->EnabledOff();
 
-  if (m_renderWindowInteractor)
+  if(getInteractor())
   {
-    m_renderWindowInteractor->Render();
+    getInteractor()->Render();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSPlaneWidget::drawPlaneOn()
+{
+  m_PlaneRep->DrawPlaneOn();
+
+  if(getInteractor())
+  {
+    getInteractor()->Render();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSPlaneWidget::drawPlaneOff()
+{
+  m_PlaneRep->DrawPlaneOff();
+  
+  if(getInteractor())
+  {
+    getInteractor()->Render();
   }
 }
 

--- a/SIMPLVtkLib/Visualization/VtkWidgets/VSPlaneWidget.cpp
+++ b/SIMPLVtkLib/Visualization/VtkWidgets/VSPlaneWidget.cpp
@@ -89,33 +89,33 @@ VSPlaneWidget::VSPlaneWidget(QWidget* parent, double bounds[6], vtkRenderWindowI
   normal[1] = 0.0;
   normal[2] = 0.0;
 
-  viewPlane = vtkSmartPointer<vtkPlane>::New();
-  viewPlane->SetNormal(normal);
-  viewPlane->SetOrigin(origin);
+  m_ViewPlane = vtkSmartPointer<vtkPlane>::New();
+  m_ViewPlane->SetNormal(normal);
+  m_ViewPlane->SetOrigin(getOrigin());
 
-  usePlane = vtkSmartPointer<vtkPlane>::New();
-  usePlane->SetNormal(normal);
-  usePlane->SetOrigin(origin);
+  m_UsePlane = vtkSmartPointer<vtkPlane>::New();
+  m_UsePlane->SetNormal(normal);
+  m_UsePlane->SetOrigin(getOrigin());
 
   vtkSmartPointer<vtkPlaneCallback> myCallback = vtkSmartPointer<vtkPlaneCallback>::New();
-  myCallback->plane = viewPlane;
+  myCallback->plane = m_ViewPlane;
   myCallback->qtPlaneWidget = this;
 
   // Implicit Plane Widget
-  planeRep = vtkImplicitPlaneRepresentation::New();
-  planeRep->SetPlaceFactor(1.25);
-  planeRep->PlaceWidget(bounds);
-  planeRep->SetNormal(viewPlane->GetNormal());
-  planeRep->SetOrigin(viewPlane->GetOrigin());
-  planeRep->SetScaleEnabled(0);
-  planeRep->SetOutlineTranslation(0);
-  planeRep->DrawPlaneOff();
-  planeRep->SetInteractionState(vtkImplicitPlaneRepresentation::Pushing);
+  m_PlaneRep = vtkImplicitPlaneRepresentation::New();
+  m_PlaneRep->SetPlaceFactor(1.25);
+  m_PlaneRep->PlaceWidget(bounds);
+  m_PlaneRep->SetNormal(m_ViewPlane->GetNormal());
+  m_PlaneRep->SetOrigin(m_ViewPlane->GetOrigin());
+  m_PlaneRep->SetScaleEnabled(0);
+  m_PlaneRep->SetOutlineTranslation(0);
+  m_PlaneRep->DrawPlaneOff();
+  m_PlaneRep->SetInteractionState(vtkImplicitPlaneRepresentation::Pushing);
 
-  planeWidget = vtkImplicitPlaneWidget2::New();
-  planeWidget->SetInteractor(iren);
-  planeWidget->SetRepresentation(planeRep);
-  planeWidget->AddObserver(vtkCommand::InteractionEvent, myCallback);
+  m_PlaneWidget = vtkImplicitPlaneWidget2::New();
+  m_PlaneWidget->SetInteractor(iren);
+  m_PlaneWidget->SetRepresentation(m_PlaneRep);
+  m_PlaneWidget->AddObserver(vtkCommand::InteractionEvent, myCallback);
 
   updateSpinBoxes();
 
@@ -134,8 +134,8 @@ VSPlaneWidget::VSPlaneWidget(QWidget* parent, double bounds[6], vtkRenderWindowI
 // -----------------------------------------------------------------------------
 VSPlaneWidget::~VSPlaneWidget()
 {
-  planeRep->Delete();
-  planeWidget->Delete();
+  m_PlaneRep->Delete();
+  m_PlaneWidget->Delete();
 }
 
 // -----------------------------------------------------------------------------
@@ -153,7 +153,7 @@ void VSPlaneWidget::getNormals(double normals[3])
 // -----------------------------------------------------------------------------
 void VSPlaneWidget::setNormals(double normals[3])
 {
-  viewPlane->SetNormal(normals);
+  m_ViewPlane->SetNormal(normals);
 
   normalXSpinBox->setValue(normals[0]);
   normalYSpinBox->setValue(normals[1]);
@@ -176,7 +176,7 @@ void VSPlaneWidget::setOrigin(double origin[3])
 {
   VSAbstractWidget::setOrigin(origin);
 
-  viewPlane->SetOrigin(origin);
+  m_ViewPlane->SetOrigin(origin);
 
   originXSpinBox->setValue(origin[0]);
   originYSpinBox->setValue(origin[1]);
@@ -197,9 +197,9 @@ void VSPlaneWidget::setOrigin(double x, double y, double z)
 // -----------------------------------------------------------------------------
 void VSPlaneWidget::updateBounds()
 {
-  planeWidget->EnabledOff();
-  planeWidget->GetRepresentation()->PlaceWidget(bounds);
-  planeWidget->EnabledOn();
+  m_PlaneWidget->EnabledOff();
+  m_PlaneWidget->GetRepresentation()->PlaceWidget(getBounds());
+  m_PlaneWidget->EnabledOn();
 }
 
 // -----------------------------------------------------------------------------
@@ -207,7 +207,7 @@ void VSPlaneWidget::updateBounds()
 // -----------------------------------------------------------------------------
 void VSPlaneWidget::updateOrigin()
 {
-  viewPlane->SetOrigin(origin);
+  m_ViewPlane->SetOrigin(getOrigin());
 }
 
 // -----------------------------------------------------------------------------
@@ -215,11 +215,11 @@ void VSPlaneWidget::updateOrigin()
 // -----------------------------------------------------------------------------
 void VSPlaneWidget::enable()
 {
-  planeWidget->EnabledOn();
+  m_PlaneWidget->EnabledOn();
 
-  if (m_renderWindowInteractor)
+  if(getInteractor())
   {
-    m_renderWindowInteractor->Render();
+    getInteractor()->Render();
   }
 }
 
@@ -228,7 +228,7 @@ void VSPlaneWidget::enable()
 // -----------------------------------------------------------------------------
 void VSPlaneWidget::disable()
 {
-  planeWidget->EnabledOff();
+  m_PlaneWidget->EnabledOff();
 
   if (m_renderWindowInteractor)
   {
@@ -242,12 +242,11 @@ void VSPlaneWidget::disable()
 void VSPlaneWidget::updateSpinBoxes()
 {
   double normals[3];
-  planeRep->GetNormal(normals);
-  planeRep->GetOrigin(origin);
+  m_PlaneRep->GetNormal(normals);
+  m_PlaneRep->GetOrigin(getOrigin());
 
   setNormals(normals);
-
-  setOrigin(origin);
+  setOrigin(getOrigin());
 }
 
 // -----------------------------------------------------------------------------
@@ -255,9 +254,11 @@ void VSPlaneWidget::updateSpinBoxes()
 // -----------------------------------------------------------------------------
 void VSPlaneWidget::spinBoxValueChanged()
 {
+  double origin[3];
   origin[0] = originXSpinBox->value();
   origin[1] = originYSpinBox->value();
   origin[2] = originZSpinBox->value();
+  setOrigin(origin);
 
   updatePlaneWidget();
 
@@ -269,21 +270,21 @@ void VSPlaneWidget::spinBoxValueChanged()
 // -----------------------------------------------------------------------------
 void VSPlaneWidget::updatePlaneWidget()
 {
-  planeWidget->Off();
+  m_PlaneWidget->Off();
 
   double normals[3];
   getNormals(normals);
 
-  viewPlane->SetNormal(normals);
-  viewPlane->SetOrigin(origin);
+  m_ViewPlane->SetNormal(normals);
+  m_ViewPlane->SetOrigin(getOrigin());
 
-  planeRep->SetPlane(viewPlane);
+  m_PlaneRep->SetPlane(m_ViewPlane);
 
-  planeWidget->On();
+  m_PlaneWidget->On();
 
-  if (m_renderWindowInteractor)
+  if(getInteractor())
   {
-    m_renderWindowInteractor->Render();
+    getInteractor()->Render();
   }
 }
 
@@ -292,6 +293,6 @@ void VSPlaneWidget::updatePlaneWidget()
 // -----------------------------------------------------------------------------
 void VSPlaneWidget::setInteractor(vtkRenderWindowInteractor* interactor)
 {
-  m_renderWindowInteractor = interactor;
-  planeWidget->SetInteractor(interactor);
+  VSAbstractWidget::setInteractor(interactor);
+  m_PlaneWidget->SetInteractor(interactor);
 }

--- a/SIMPLVtkLib/Visualization/VtkWidgets/VSPlaneWidget.h
+++ b/SIMPLVtkLib/Visualization/VtkWidgets/VSPlaneWidget.h
@@ -153,8 +153,8 @@ protected:
 
 private:
 
-  vtkSmartPointer<vtkPlane> usePlane;
-  vtkSmartPointer<vtkPlane> viewPlane;
-  vtkImplicitPlaneWidget2* planeWidget;
-  vtkImplicitPlaneRepresentation* planeRep;
+  vtkSmartPointer<vtkPlane> m_UsePlane;
+  vtkSmartPointer<vtkPlane> m_ViewPlane;
+  vtkImplicitPlaneWidget2* m_PlaneWidget;
+  vtkImplicitPlaneRepresentation* m_PlaneRep;
 };

--- a/SIMPLVtkLib/Visualization/VtkWidgets/VSPlaneWidget.h
+++ b/SIMPLVtkLib/Visualization/VtkWidgets/VSPlaneWidget.h
@@ -124,6 +124,16 @@ public:
   void disable() override;
 
   /**
+  * @brief Enables rendering the plane internals
+  */
+  void drawPlaneOn();
+
+  /**
+  * @brief Disables rendering the plane internals
+  */
+  void drawPlaneOff();
+
+  /**
   * @brief Updates the origin and normal values based on the VTK plane widget 
   * before applying those values to the input widgets.
   */


### PR DESCRIPTION
* Plane representations no longer render the transparent internal plane when apply or reset buttons are pressed but do render the plane when the representation values are modified.

* Updated variable names and permissions in VSAbstractWidget, VSBoxWidget, and VSPlaneWidget to better match the rest of the library

* Added a missing description for VSBoxWidget's setInteractor method