### PR TITLE
Feature/actor representation

### DIFF
--- a/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
+++ b/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
@@ -215,41 +215,7 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="arrayLabel">
-            <property name="text">
-             <string>Array:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="activeArrayCombo">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="activeComponentCombo">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="componentLabel">
-            <property name="text">
-             <string>Component:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="VSColorButton" name="colorBtn">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -262,11 +228,76 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="activeArrayCombo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="arrayLabel">
+            <property name="text">
+             <string>Array:</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="0">
+           <widget class="QLabel" name="componentLabel">
+            <property name="text">
+             <string>Component:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="activeComponentCombo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
            <widget class="QLabel" name="colorLabel">
             <property name="text">
              <string>Color: </string>
             </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="representationLabel">
+            <property name="text">
+             <string>Representation:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="representationCombo">
+            <item>
+             <property name="text">
+              <string>Point</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Wireframe</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Surface</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Surface With Edges</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>

--- a/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
+++ b/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
@@ -215,6 +215,30 @@
           <property name="spacing">
            <number>4</number>
           </property>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="representationCombo">
+            <item>
+             <property name="text">
+              <string>Point</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Wireframe</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Surface</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Surface With Edges</string>
+             </property>
+            </item>
+           </widget>
+          </item>
           <item row="3" column="1">
            <widget class="VSColorButton" name="colorBtn">
             <property name="sizePolicy">
@@ -269,35 +293,11 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="representationLabel">
             <property name="text">
              <string>Representation:</string>
             </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="representationCombo">
-            <item>
-             <property name="text">
-              <string>Point</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Wireframe</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Surface</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Surface With Edges</string>
-             </property>
-            </item>
            </widget>
           </item>
          </layout>

--- a/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
@@ -80,6 +80,8 @@ void VSInfoWidget::setupGui()
 {
   m_presetsDialog = new ColorPresetsDialog();
 
+  connect(m_Internals->representationCombo, SIGNAL(currentIndexChanged(int)),
+    this, SLOT(setRepresentationIndex(int)));
   connect(m_Internals->activeArrayCombo, SIGNAL(currentIndexChanged(int)),
     this, SLOT(updateActiveArrayIndex(int)));
   connect(m_Internals->activeComponentCombo, SIGNAL(currentIndexChanged(int)),
@@ -225,6 +227,8 @@ void VSInfoWidget::connectFilterViewSettings(VSFilterViewSettings* settings)
 {
   if(m_ViewSettings)
   {
+    disconnect(settings, SIGNAL(representationChanged(VSFilterViewSettings*, VSFilterViewSettings::Representation)),
+      this, SLOT(listenRepresentationType(VSFilterViewSettings*, VSFilterViewSettings::Representation)));
     disconnect(settings, SIGNAL(activeArrayIndexChanged(VSFilterViewSettings*, int)),
       this, SLOT(listenArrayIndex(VSFilterViewSettings*, int)));
     disconnect(settings, SIGNAL(activeComponentIndexChanged(VSFilterViewSettings*, int)),
@@ -243,6 +247,9 @@ void VSInfoWidget::connectFilterViewSettings(VSFilterViewSettings* settings)
 
   if(m_ViewSettings)
   {
+    
+    connect(settings, SIGNAL(representationChanged(VSFilterViewSettings*, VSFilterViewSettings::Representation)),
+      this, SLOT(listenRepresentationType(VSFilterViewSettings*, VSFilterViewSettings::Representation)));
     connect(settings, SIGNAL(activeArrayIndexChanged(VSFilterViewSettings*, int)),
       this, SLOT(listenArrayIndex(VSFilterViewSettings*, int)));
     connect(settings, SIGNAL(activeComponentIndexChanged(VSFilterViewSettings*, int)),
@@ -326,6 +333,9 @@ void VSInfoWidget::updateViewSettingInfo()
   bool validSettings = m_ViewSettings && m_ViewSettings->isValid();
   m_Internals->viewSettingsWidget->setEnabled(validSettings);
 
+  // Representation
+  m_Internals->representationCombo->setCurrentIndex(m_ViewSettings->getRepresentation());
+
   int activeArrayIndex = m_ViewSettings->getActiveArrayIndex();
   int activeComponentIndex = m_ViewSettings->getActiveComponentIndex() + 1;
 
@@ -350,6 +360,20 @@ void VSInfoWidget::updateViewSettingInfo()
     QColor newColor = QColor::fromRgbF(solidColor[0], solidColor[1], solidColor[2]);
     m_Internals->colorBtn->setColor(newColor, false);
   }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSInfoWidget::setRepresentationIndex(int index)
+{
+  if(nullptr == m_ViewSettings)
+  {
+    return;
+  }
+
+  VSFilterViewSettings::Representation rep = static_cast<VSFilterViewSettings::Representation>(index);
+  m_ViewSettings->setRepresentation(rep);
 }
 
 // -----------------------------------------------------------------------------
@@ -506,6 +530,14 @@ void VSInfoWidget::colorButtonChanged(QColor color)
   colorArray[2] = color.blueF();
 
   m_ViewSettings->setSolidColor(colorArray);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSInfoWidget::listenRepresentationType(VSFilterViewSettings* settings, VSFilterViewSettings::Representation rep)
+{
+  m_Internals->representationCombo->setCurrentIndex(rep);
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/QtWidgets/VSInfoWidget.h
+++ b/SIMPLVtkLib/QtWidgets/VSInfoWidget.h
@@ -97,6 +97,12 @@ public slots:
 
 protected slots:
   /**
+  * @brief Sets the actorRepresentation for the current filter
+  * @param index
+  */
+  void setRepresentationIndex(int index);
+
+  /**
   * @brief Handles the active array combo box being changed
   * @param index
   */
@@ -148,6 +154,13 @@ protected slots:
   * @param color
   */
   void colorButtonChanged(QColor color);
+
+  /**
+  * @brief Listens for the active VSFilterViewSettings representation type to change
+  * @param settings
+  * @param rep
+  */
+  void listenRepresentationType(VSFilterViewSettings* settings, VSFilterViewSettings::Representation rep);
 
   /**
   * @brief Listens for the active VSFilterViewSettings active array index to change

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -52,6 +52,7 @@ VSFilterViewSettings::VSFilterViewSettings(VSAbstractFilter* filter)
 {
   connectFilter(filter);
   setupActors();
+  setRepresentation(Representation::Default);
 }
 
 // -----------------------------------------------------------------------------
@@ -619,6 +620,53 @@ void VSFilterViewSettings::setSolidColor(double color[3])
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+VSFilterViewSettings::Representation VSFilterViewSettings::getRepresentation()
+{
+  if(false == isValid())
+  {
+    return Representation::Invalid;
+  }
+
+  vtkProperty* property = m_Actor->GetProperty();
+  int rep = property->GetRepresentation();
+  int edges = property->GetEdgeVisibility();
+
+  if(1 == edges && Representation::Surface == rep)
+  {
+    return Representation::SurfaceWithEdges;
+  }
+
+  return static_cast<Representation>(rep);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSFilterViewSettings::setRepresentation(Representation type)
+{
+  if(false == isValid())
+  {
+    return;
+  }
+
+  if(type == Representation::SurfaceWithEdges)
+  {
+    m_Actor->GetProperty()->SetRepresentation(Representation::Surface);
+    m_Actor->GetProperty()->EdgeVisibilityOn();
+  }
+  else
+  {
+    m_Actor->GetProperty()->SetRepresentation(type);
+    m_Actor->GetProperty()->EdgeVisibilityOff();
+  }
+
+  emit representationChanged(this, type);
+  emit requiresRender();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void VSFilterViewSettings::copySettings(VSFilterViewSettings* copy)
 {
   if((nullptr == copy) || (false == copy->isValid()))
@@ -640,6 +688,7 @@ void VSFilterViewSettings::copySettings(VSFilterViewSettings* copy)
   setScalarBarVisible(copy->m_ShowScalarBar);
   setAlpha(copy->m_Alpha);
   setSolidColor(copy->getSolidColor());
+  setRepresentation(copy->getRepresentation());
 
   if(hasUi)
   {

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
@@ -66,6 +66,16 @@ class SIMPLVtkLib_EXPORT VSFilterViewSettings : public QObject
 public:
   using Map = std::map<VSAbstractFilter*, VSFilterViewSettings*>;
 
+  enum Representation : int
+  {
+    Invalid = -1,
+    Points = 0,
+    Wireframe = 1,
+    Surface = 2,
+    SurfaceWithEdges = 3,
+    Default = Surface
+  };
+
   /**
   * @brief Constructor
   * @param filter
@@ -163,6 +173,12 @@ public:
   double* getSolidColor();
 
   /**
+  * @brief Returns the actor property representation
+  * @return
+  */
+  Representation getRepresentation();
+
+  /**
   * @brief Copies another VSFilterViewSettings for everything but the active filter
   * @param filter
   */
@@ -234,6 +250,12 @@ public slots:
   void setSolidColor(double color[3]);
 
   /**
+  * @brief Sets the actor property representation
+  * @param type
+  */
+  void setRepresentation(Representation type);
+
+  /**
   * @brief Updates the input connection for the vtkMapper
   * @param filter
   */
@@ -241,6 +263,7 @@ public slots:
 
 signals:
   void visibilityChanged(VSFilterViewSettings*, bool);
+  void representationChanged(VSFilterViewSettings*, Representation);
   void solidColorChanged(VSFilterViewSettings*, double*);
   void activeArrayIndexChanged(VSFilterViewSettings*, int);
   void activeComponentIndexChanged(VSFilterViewSettings*, int);


### PR DESCRIPTION
* Added a Representation enum to VSFilterViewSettings to represent which type of actor representation is being displayed.  The current options are Point, Wireframe, Surface, and Surface With Edges.

* Added a QComboBox to VSInfoWidget to control the current VSFilterViewRepresentation and display it to the user.