### PR TITLE
feature/abstract data filter

### DIFF
--- a/SIMPLVtkLib/Visualization/VisualFilters/SourceList.cmake
+++ b/SIMPLVtkLib/Visualization/VisualFilters/SourceList.cmake
@@ -1,5 +1,6 @@
 
 set(VSVisualFilters
+  VSAbstractDataFilter
   VSAbstractFilter
   VSClipFilter
   VSCropFilter

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractDataFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractDataFilter.cpp
@@ -33,81 +33,49 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#pragma once
+#include "VSAbstractDataFilter.h"
 
-#include <QtWidgets/QWidget>
-
-#include <vtkSmartPointer.h>
-
-#include "SIMPLVtkLib/SIMPLBridge/SIMPLVtkBridge.h"
-#include "SIMPLVtkLib/Visualization/VisualFilters/VSAbstractDataFilter.h"
-
-#include "SIMPLVtkLib/SIMPLVtkLib.h"
-
-class vtkTrivialProducer;
-class vtkAlgorithmOutput;
-
-/**
-* @class VSSIMPLDataContainerFilter VSSIMPLDataContainerFilter.h
-* SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.h
-* @brief This class stores a WrappedDataContainerPtr and provides an output port
-* for other filters to connect to for converting SIMPLib DataContainers to something 
-* VTK can render.
-*/
-class SIMPLVtkLib_EXPORT VSSIMPLDataContainerFilter : public VSAbstractDataFilter
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+VSAbstractDataFilter::VSAbstractDataFilter()
+  : VSAbstractFilter()
 {
-  Q_OBJECT
+}
 
-public:
-  /**
-  * @brief Constuctor
-  * @param parentWidget
-  * @param dataSetStruct
-  */
-  VSSIMPLDataContainerFilter(SIMPLVtkBridge::WrappedDataContainerPtr wrappedDataContainer);
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+VSAbstractFilter::dataType_t VSAbstractDataFilter::getRequiredInputType()
+{
+  return ANY_DATA_SET;
+}
 
-  /**
-  * @brief Returns the bounds of the vtkDataSet
-  * @return
-  */
-  double* getBounds() const;
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSAbstractDataFilter::updateAlgorithmInput(VSAbstractFilter* filter)
+{
+  // Do nothing
+}
 
-  /**
-  * @brief Returns the output port for the filter
-  * @return
-  */
-  virtual vtkAlgorithmOutput* getOutputPort() override;
-
-  /**
-  * @brief Returns the output data for the filter
-  */
-  VTK_PTR(vtkDataSet) getOutput() override;
-
-  /**
-  * @brief Returns the filter's name
-  * @return
-  */
-  const QString getFilterName() override;
-    
-  /**
-  * @brief Returns the tooltip to use for the filter
-  * @return
-  */
-  virtual QString getToolTip() const override;
-
-  /**
-  * @brief Returns the VtkDataSetStruct_t used by the filter
-  * @return
-  */
-  SIMPLVtkBridge::WrappedDataContainerPtr getWrappedDataContainer() override;
-
-protected:
-  /**
-  * @brief Initializes the trivial producer and connects it to the vtkMapper
-  */
-  void createFilter() override;
-
-private:
-  SIMPLVtkBridge::WrappedDataContainerPtr m_WrappedDataContainer = nullptr;
-  VTK_PTR(vtkTrivialProducer) m_TrivialProducer = nullptr;
-};
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+VSAbstractFilter::dataType_t VSAbstractDataFilter::getOutputType()
+{
+  switch(getOutput()->GetDataObjectType())
+  {
+  case VTK_STRUCTURED_GRID:
+  case VTK_RECTILINEAR_GRID:
+    return dataType_t::IMAGE_DATA;
+  case VTK_STRUCTURED_POINTS:
+    return dataType_t::POINT_DATA;
+  case VTK_UNSTRUCTURED_GRID:
+    return dataType_t::UNSTRUCTURED_GRID;
+  case VTK_POLY_DATA:
+    return dataType_t::POLY_DATA;
+  default:
+    return dataType_t::INVALID_DATA;
+  }
+}

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractDataFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractDataFilter.h
@@ -35,79 +35,41 @@
 
 #pragma once
 
-#include <QtWidgets/QWidget>
-
-#include <vtkSmartPointer.h>
-
-#include "SIMPLVtkLib/SIMPLBridge/SIMPLVtkBridge.h"
-#include "SIMPLVtkLib/Visualization/VisualFilters/VSAbstractDataFilter.h"
-
-#include "SIMPLVtkLib/SIMPLVtkLib.h"
-
-class vtkTrivialProducer;
-class vtkAlgorithmOutput;
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h"
 
 /**
-* @class VSSIMPLDataContainerFilter VSSIMPLDataContainerFilter.h
-* SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.h
-* @brief This class stores a WrappedDataContainerPtr and provides an output port
-* for other filters to connect to for converting SIMPLib DataContainers to something 
-* VTK can render.
+* @class VSAbstractDataFilter VSAbstractDataFilter.h 
+* SIMPLVtkLib/Visualization/VisualFilters/VSAbstractDataFilter.h
+* @brief This is the base class for classes that import data into the project.
+* Its primary purpose is to have a common ancestor and handle required methods
+* from VSAbstractFilter that are not used or have differing applications between
+* data filters.
 */
-class SIMPLVtkLib_EXPORT VSSIMPLDataContainerFilter : public VSAbstractDataFilter
+class SIMPLVtkLib_EXPORT VSAbstractDataFilter : public VSAbstractFilter
 {
-  Q_OBJECT
-
 public:
   /**
-  * @brief Constuctor
-  * @param parentWidget
-  * @param dataSetStruct
+  * @brief Constructor
   */
-  VSSIMPLDataContainerFilter(SIMPLVtkBridge::WrappedDataContainerPtr wrappedDataContainer);
+  VSAbstractDataFilter();
 
   /**
-  * @brief Returns the bounds of the vtkDataSet
+  * @brief Returns the required input data type
   * @return
   */
-  double* getBounds() const;
+  static dataType_t getRequiredInputType();
 
   /**
-  * @brief Returns the output port for the filter
+  * @brief Returns the output data type for the filter
   * @return
   */
-  virtual vtkAlgorithmOutput* getOutputPort() override;
-
-  /**
-  * @brief Returns the output data for the filter
-  */
-  VTK_PTR(vtkDataSet) getOutput() override;
-
-  /**
-  * @brief Returns the filter's name
-  * @return
-  */
-  const QString getFilterName() override;
-    
-  /**
-  * @brief Returns the tooltip to use for the filter
-  * @return
-  */
-  virtual QString getToolTip() const override;
-
-  /**
-  * @brief Returns the VtkDataSetStruct_t used by the filter
-  * @return
-  */
-  SIMPLVtkBridge::WrappedDataContainerPtr getWrappedDataContainer() override;
+  dataType_t getOutputType() override;
 
 protected:
   /**
-  * @brief Initializes the trivial producer and connects it to the vtkMapper
+  * @brief This method is empty as there should never be a case where a VSAbstractDataFilter
+  * takes input from another filter.
+  * @param filter
   */
-  void createFilter() override;
-
-private:
-  SIMPLVtkBridge::WrappedDataContainerPtr m_WrappedDataContainer = nullptr;
-  VTK_PTR(vtkTrivialProducer) m_TrivialProducer = nullptr;
+  void updateAlgorithmInput(VSAbstractFilter* filter) override;
 };

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h
@@ -87,7 +87,9 @@ public:
     IMAGE_DATA,
     UNSTRUCTURED_GRID,
     POLY_DATA,
-    ANY_DATA_SET
+    POINT_DATA,
+    ANY_DATA_SET,
+    INVALID_DATA
   };
 
   /**

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.cpp
@@ -57,7 +57,7 @@
 //
 // -----------------------------------------------------------------------------
 VSDataSetFilter::VSDataSetFilter(const QString &filePath)
-  : VSAbstractFilter()
+  : VSAbstractDataFilter()
   , m_FilePath(filePath)
 {
   createFilter();
@@ -102,14 +102,6 @@ VTK_PTR(vtkDataSet) VSDataSetFilter::getOutput()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSDataSetFilter::updateAlgorithmInput(VSAbstractFilter* filter)
-{
-  // Do nothing
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void VSDataSetFilter::createFilter()
 {
   QFileInfo fi(m_FilePath);
@@ -120,6 +112,7 @@ void VSDataSetFilter::createFilter()
   QString mimeName = mimeType.name();
 
   setText(fi.fileName());
+  setToolTip(m_FilePath);
 
   if (mimeType.name().startsWith("image/"))
   {
@@ -263,22 +256,5 @@ const QString VSDataSetFilter::getFilterName()
 // -----------------------------------------------------------------------------
 QString VSDataSetFilter::getToolTip() const
 {
-  return "Dataset Filter";
+  return m_FilePath;
 }
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-VSAbstractFilter::dataType_t VSDataSetFilter::getOutputType()
-{
-  return IMAGE_DATA;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-VSAbstractFilter::dataType_t VSDataSetFilter::getRequiredInputType()
-{
-  return ANY_DATA_SET;
-}
-

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.h
@@ -37,11 +37,10 @@
 
 #include <QtWidgets/QWidget>
 
-#include "VSAbstractFilter.h"
-
 #include <vtkSmartPointer.h>
 
 #include "SIMPLVtkLib/SIMPLBridge/SIMPLVtkBridge.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSAbstractDataFilter.h"
 
 #include "SIMPLVtkLib/SIMPLVtkLib.h"
 
@@ -55,12 +54,12 @@ class vtkAlgorithmOutput;
 * for other filters to connect to for converting SIMPLib DataContainers to something 
 * VTK can render.
 */
-class SIMPLVtkLib_EXPORT VSDataSetFilter : public VSAbstractFilter
+class SIMPLVtkLib_EXPORT VSDataSetFilter : public VSAbstractDataFilter
 {
   Q_OBJECT
 
 public:
-    /**
+  /**
    * @brief Constructor
    * @param filePath
    */
@@ -96,29 +95,16 @@ public:
   virtual QString getToolTip() const override;
 
   /**
-  * @brief Returns the output data type for the filter
-  * @return
-  */
-  dataType_t getOutputType() override;
-
-  /**
   * @brief Returns the required input data type
   * @return
   */
-  static dataType_t getRequiredInputType();
+  //static dataType_t getRequiredInputType();
 
 protected:
   /**
   * @brief Initializes the trivial producer and connects it to the vtkMapper
   */
   void createFilter() override;
-
-  /**
-  * @brief This method is empty as there should never be a case where a VSDataSetFilter
-  * is a child of another filter.
-  * @param filter
-  */
-  void updateAlgorithmInput(VSAbstractFilter* filter) override;
 
 private:
   QString m_FilePath;

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.cpp
@@ -53,7 +53,7 @@
 //
 // -----------------------------------------------------------------------------
 VSSIMPLDataContainerFilter::VSSIMPLDataContainerFilter(SIMPLVtkBridge::WrappedDataContainerPtr wrappedDataContainer)
-: VSAbstractFilter()
+: VSAbstractDataFilter()
 , m_WrappedDataContainer(wrappedDataContainer)
 {
   createFilter();
@@ -96,14 +96,6 @@ VTK_PTR(vtkDataSet) VSSIMPLDataContainerFilter::getOutput()
   }
 
   return m_WrappedDataContainer->m_DataSet;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void VSSIMPLDataContainerFilter::updateAlgorithmInput(VSAbstractFilter* filter)
-{
-  // Do nothing
 }
 
 // -----------------------------------------------------------------------------
@@ -153,20 +145,4 @@ QString VSSIMPLDataContainerFilter::getToolTip() const
 SIMPLVtkBridge::WrappedDataContainerPtr VSSIMPLDataContainerFilter::getWrappedDataContainer()
 {
   return m_WrappedDataContainer;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-VSAbstractFilter::dataType_t VSSIMPLDataContainerFilter::getOutputType()
-{
-  return IMAGE_DATA;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-VSAbstractFilter::dataType_t VSSIMPLDataContainerFilter::getRequiredInputType()
-{
-  return ANY_DATA_SET;
 }


### PR DESCRIPTION
Created an AbstractDataFilter from which VSDataSetFilter and VSSIMPLDataContainerFilter are parented.  Both existing classes had their getOutputType and getRequiredInputType methods moved to VSAbstractDataFilter.  The output type is returned based on the type of VTK data output by the filter as this may differ based on which type of data is imported or created.  This also corrects VSDataSetFilter incorrectly stating it always outputs Image data when it may be outputing poly or unstructured grid data instead.