### PR TITLE
Feature/file filter

### DIFF
--- a/SIMPLVtkLib/Visualization/Controllers/VSController.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSController.cpp
@@ -61,11 +61,11 @@ VSController::~VSController()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void VSController::importDataContainerArray(QString textLabel, QString tooltip, DataContainerArray::Pointer dca)
+void VSController::importDataContainerArray(QString filePath, DataContainerArray::Pointer dca)
 {
   std::vector<SIMPLVtkBridge::WrappedDataContainerPtr> wrappedData = SIMPLVtkBridge::WrapDataContainerArrayAsStruct(dca);
 
-  VSTextFilter* textFilter = new VSTextFilter(nullptr, textLabel, tooltip);
+  VSFileNameFilter* textFilter = new VSFileNameFilter(filePath);
   m_FilterModel->addFilter(textFilter);
 
   // Add VSDataSetFilter for each DataContainer with relevant data
@@ -119,22 +119,30 @@ void VSController::importDataContainer(DataContainer::Pointer dc)
 void VSController::importData(const QString &filePath)
 {
   VSDataSetFilter* filter = new VSDataSetFilter(filePath);
-  m_FilterModel->addFilter(filter);
+  // Check if any data was imported
+  if(filter->getOutput())
+  {
+    VSFileNameFilter* textFilter = new VSFileNameFilter(filePath);
+    m_FilterModel->addFilter(textFilter);
 
-  emit dataImported();
+    filter->setParentFilter(textFilter);
+    m_FilterModel->addFilter(filter);
+
+    emit dataImported();
+  }
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-VSTextFilter* VSController::getBaseTextFilter(QString text)
+VSFileNameFilter* VSController::getBaseFileNameFilter(QString text)
 {
   QVector<VSAbstractFilter*> baseFilters = getBaseFilters();
   int count = baseFilters.size();
 
   for(int i = 0; i < count; i++)
   {
-    VSTextFilter* filter = dynamic_cast<VSTextFilter*>(baseFilters[i]);
+    VSFileNameFilter* filter = dynamic_cast<VSFileNameFilter*>(baseFilters[i]);
     if(filter)
     {
       if(filter->getFilterName().compare(text) == 0)

--- a/SIMPLVtkLib/Visualization/Controllers/VSController.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSController.h
@@ -42,7 +42,7 @@
 
 #include "SIMPLVtkLib/SIMPLBridge/SIMPLVtkBridge.h"
 #include "SIMPLVtkLib/Visualization/Controllers/VSFilterModel.h"
-#include "SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.h"
 
 #include "SIMPLVtkLib/SIMPLVtkLib.h"
 
@@ -73,7 +73,7 @@ public:
   * as top-level VisualFilters
   * @param dca
   */
-  void importDataContainerArray(QString textLabel, QString tooltip, DataContainerArray::Pointer dca);
+  void importDataContainerArray(QString filePath, DataContainerArray::Pointer dca);
 
   /**
   * @brief Import data from a DataContainerArray and add any relevant DataContainers
@@ -100,7 +100,7 @@ public:
   * @param text
   * @return
   */
-  VSTextFilter* getBaseTextFilter(QString text);
+  VSFileNameFilter* getBaseFileNameFilter(QString text);
 
   /**
   * @brief Returns a vector of top-level data filters

--- a/SIMPLVtkLib/Visualization/VisualFilters/SourceList.cmake
+++ b/SIMPLVtkLib/Visualization/VisualFilters/SourceList.cmake
@@ -5,6 +5,7 @@ set(VSVisualFilters
   VSClipFilter
   VSCropFilter
   VSDataSetFilter
+  VSFileNameFilter
   VSMaskFilter
   VSSIMPLDataContainerFilter
   VSSliceFilter

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSDataSetFilter.cpp
@@ -111,9 +111,6 @@ void VSDataSetFilter::createFilter()
   QMimeType mimeType = db.mimeTypeForFile(m_FilePath, QMimeDatabase::MatchContent);
   QString mimeName = mimeType.name();
 
-  setText(fi.fileName());
-  setToolTip(m_FilePath);
-
   if (mimeType.name().startsWith("image/"))
   {
     readImage();
@@ -128,14 +125,38 @@ void VSDataSetFilter::createFilter()
     readSTLFile();
   }
 
-  if (m_DataSet != nullptr)
+  if(m_DataSet != nullptr)
   {
+    dataType_t outputType = getOutputType();
+    switch(outputType)
+    {
+    case dataType_t::IMAGE_DATA:
+      setText("Image Data");
+      break;
+    case dataType_t::POINT_DATA:
+      setText("Point Data");
+      break;
+    case dataType_t::POLY_DATA:
+      setText("Poly Data");
+      break;
+    case dataType_t::UNSTRUCTURED_GRID:
+      setText("Unstructured Grid Data");
+      break;
+    default:
+      setText("Other Data");
+      break;
+    }
+
     m_DataSet->ComputeBounds();
 
     m_TrivialProducer = VTK_PTR(vtkTrivialProducer)::New();
     m_TrivialProducer->SetOutput(m_DataSet);
 
     emit updatedOutputPort(this);
+  }
+  else
+  {
+    setText("Invalid Import File");
   }
 }
 
@@ -256,5 +277,5 @@ const QString VSDataSetFilter::getFilterName()
 // -----------------------------------------------------------------------------
 QString VSDataSetFilter::getToolTip() const
 {
-  return m_FilePath;
+  return "DataSet Filter";
 }

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.cpp
@@ -40,7 +40,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QString getFileName(QString filePath)
+QString fetchFileName(QString filePath)
 {
   QFileInfo fi(filePath);
   if(fi.exists())
@@ -54,10 +54,28 @@ QString getFileName(QString filePath)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-VSFileNameFilter::VSFileNameFilter(VSAbstractFilter* parentFilter, QString filePath)
-  : VSTextFilter(parentFilter, getFileName(filePath), filePath)
+VSFileNameFilter::VSFileNameFilter(QString filePath)
+  : VSTextFilter(nullptr, fetchFileName(filePath), filePath)
+  , m_FilePath(filePath)
 {
   setCheckState(Qt::Unchecked);
   setCheckable(false);
   setEditable(false);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSFileNameFilter::getFilePath()
+{
+  return m_FilePath;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString VSFileNameFilter::getFileName()
+{
+  QFileInfo fi(m_FilePath);
+  return fi.fileName();
 }

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.cpp
@@ -33,90 +33,31 @@
 *
 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#pragma once
+#include "VSFileNameFilter.h"
 
-#include "SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h"
+#include <QtCore/QFileInfo>
 
-/**
-* @class VSTextFilter VSTextFilter.h 
-* SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h
-* @brief This class is used for nothing more than giving its children some sort 
-* of text label.  This filter does not create any data or modify incoming data 
-* in any way.
-*/
-class SIMPLVtkLib_EXPORT VSTextFilter : public VSAbstractFilter
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QString getFileName(QString filePath)
 {
-  Q_OBJECT
+  QFileInfo fi(filePath);
+  if(fi.exists())
+  {
+    return fi.fileName();
+  }
 
-public:
-  /**
-  * @brief Constructor
-  * @param parent
-  * @param text
-  */
-  VSTextFilter(VSAbstractFilter* parent, QString text, QString toolTip);
+  return "File not Found";
+}
 
-  /**
-  * @brief Returns the filter's name
-  * @return
-  */
-  virtual const QString getFilterName() override;
-
-  /**
-  * @brief Returns the filter's tooltip
-  */
-  virtual QString getToolTip() const override;
-
-  /**
-  * @brief Sets whether or not the font is italic
-  * @param italic
-  */
-  void setItalic(bool italic = true);
-
-  /**
-  * @brief Sets whether or not the font is bold
-  * @param bold
-  */
-  void setBold(bool bold = true);
-
-  /**
-  * @brief Sets whether or not the font is underlined
-  * @param underline
-  */
-  void setUnderline(bool underline = true);
-
-  /**
-  * @brief Returns the output port to be used by vtkMappers and subsequent filters
-  * @return
-  */
-  virtual vtkAlgorithmOutput* getOutputPort() override;
-
-  /**
-  * @brief Returns a smart pointer containing the output data from the filter
-  * @return
-  */
-  virtual VTK_PTR(vtkDataSet) getOutput() override;
-
-  /**
-  * @brief Returns the ouput data type
-  * @return
-  */
-  dataType_t getOutputType() override;
-
-  /**
-  * @brief Returns the required incoming data type
-  */
-  static dataType_t getRequiredInputType();
-
-protected:
-  /**
-  * @brief createFilter() not required by VSTextFilter
-  */
-  void createFilter() override;
-
-  /**
-  * @brief Updates the input port
-  * @param filter
-  */
-  void updateAlgorithmInput(VSAbstractFilter* filter) override;
-};
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+VSFileNameFilter::VSFileNameFilter(VSAbstractFilter* parentFilter, QString filePath)
+  : VSTextFilter(parentFilter, getFileName(filePath), filePath)
+{
+  setCheckState(Qt::Unchecked);
+  setCheckable(false);
+  setEditable(false);
+}

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.h
@@ -35,88 +35,12 @@
 
 #pragma once
 
-#include "SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h"
 
-/**
-* @class VSTextFilter VSTextFilter.h 
-* SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h
-* @brief This class is used for nothing more than giving its children some sort 
-* of text label.  This filter does not create any data or modify incoming data 
-* in any way.
-*/
-class SIMPLVtkLib_EXPORT VSTextFilter : public VSAbstractFilter
+class SIMPLVtkLib_EXPORT VSFileNameFilter : public VSTextFilter
 {
   Q_OBJECT
 
 public:
-  /**
-  * @brief Constructor
-  * @param parent
-  * @param text
-  */
-  VSTextFilter(VSAbstractFilter* parent, QString text, QString toolTip);
-
-  /**
-  * @brief Returns the filter's name
-  * @return
-  */
-  virtual const QString getFilterName() override;
-
-  /**
-  * @brief Returns the filter's tooltip
-  */
-  virtual QString getToolTip() const override;
-
-  /**
-  * @brief Sets whether or not the font is italic
-  * @param italic
-  */
-  void setItalic(bool italic = true);
-
-  /**
-  * @brief Sets whether or not the font is bold
-  * @param bold
-  */
-  void setBold(bool bold = true);
-
-  /**
-  * @brief Sets whether or not the font is underlined
-  * @param underline
-  */
-  void setUnderline(bool underline = true);
-
-  /**
-  * @brief Returns the output port to be used by vtkMappers and subsequent filters
-  * @return
-  */
-  virtual vtkAlgorithmOutput* getOutputPort() override;
-
-  /**
-  * @brief Returns a smart pointer containing the output data from the filter
-  * @return
-  */
-  virtual VTK_PTR(vtkDataSet) getOutput() override;
-
-  /**
-  * @brief Returns the ouput data type
-  * @return
-  */
-  dataType_t getOutputType() override;
-
-  /**
-  * @brief Returns the required incoming data type
-  */
-  static dataType_t getRequiredInputType();
-
-protected:
-  /**
-  * @brief createFilter() not required by VSTextFilter
-  */
-  void createFilter() override;
-
-  /**
-  * @brief Updates the input port
-  * @param filter
-  */
-  void updateAlgorithmInput(VSAbstractFilter* filter) override;
+  VSFileNameFilter(VSAbstractFilter* parentFilter, QString filePath);
 };

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.h
@@ -37,10 +37,38 @@
 
 #include "SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h"
 
+/**
+* @class VSFileNameFilter VSFileNameFilter.h
+* SIMPLVtkLib/Visualization/VisualFilters/VSFileNameFilter.h
+* @brief This class handles the file path and contains additional settings in 
+* addition to VSTextFilter's for displaying the file information in the filter 
+* model. The file path and file name can always be retrieved even if the text
+* and tool tip are changed.
+*/
 class SIMPLVtkLib_EXPORT VSFileNameFilter : public VSTextFilter
 {
   Q_OBJECT
 
 public:
-  VSFileNameFilter(VSAbstractFilter* parentFilter, QString filePath);
+  /**
+  * @brief Constructor
+  * @param parentFilter
+  * @param filePath
+  */
+  VSFileNameFilter(QString filePath);
+
+  /**
+  * @brief Returns the stored file path
+  * @return
+  */
+  QString getFilePath();
+
+  /**
+  * @brief Returns the file name
+  * @return
+  */
+  QString getFileName();
+
+private:
+  QString m_FilePath;
 };

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.cpp
@@ -42,20 +42,12 @@
 // -----------------------------------------------------------------------------
 VSTextFilter::VSTextFilter(VSAbstractFilter* parent, QString text, QString toolTip)
   : VSAbstractFilter()
-  , m_Text(text)
-  , m_ToolTip(toolTip)
 {
   setParentFilter(parent);
 
-  setCheckState(Qt::Unchecked);
-  setCheckable(false);
-  setEditable(false);
-  
-  setText(getFilterName());
+  setText(text);
   setToolTip(toolTip);
-  QFont itemFont = font();
-  itemFont.setItalic(true);
-  setFont(itemFont);
+  setItalic();
 }
 
 // -----------------------------------------------------------------------------
@@ -63,7 +55,7 @@ VSTextFilter::VSTextFilter(VSAbstractFilter* parent, QString text, QString toolT
 // -----------------------------------------------------------------------------
 const QString VSTextFilter::getFilterName()
 {
-  return m_Text;
+  return text();
 }
 
 // -----------------------------------------------------------------------------
@@ -71,7 +63,37 @@ const QString VSTextFilter::getFilterName()
 // -----------------------------------------------------------------------------
 QString VSTextFilter::getToolTip() const
 {
-  return m_ToolTip;
+  return toolTip();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSTextFilter::setItalic(bool italic)
+{
+  QFont itemFont = font();
+  itemFont.setItalic(italic);
+  setFont(itemFont);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSTextFilter::setBold(bool bold)
+{
+  QFont itemFont = font();
+  itemFont.setBold(bold);
+  setFont(itemFont);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSTextFilter::setUnderline(bool underline)
+{
+  QFont itemFont = font();
+  itemFont.setUnderline(underline);
+  setFont(itemFont);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
* Added a new subclass of VSTextFilter called VSFileNameFilter for use in storing and displaying file paths.

* Added additional settings to VSTextFilter for setting the bold, italic, and underline properties.

* Moved the Uneditable and Uncheckable settings from VSTextFilter to VSFileNameFilter.

* Changed VSController to use VSFileNameFilter instead of VSTextFilter for handling imported file paths.

* Changed VSController to use VSFileNameFilter for importing data through the VSDataSetFilter to keep it consistent with the VSSIMPLDataContainerFilter.  If the VSDataSetFilter does not import any data, the filter is not added to the model.

* Changed VSDataSetFilter to use the output data type (image, unstructured grid, poly, point, etc.) instead of its file name to better match VSSIMPLDataContainerFilter and prevent displaying duplicates of the file name being displayed due to the use of VSFileNameFilter.