### PR TITLE
feature/info widget sizing

### DIFF
--- a/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
+++ b/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
@@ -127,6 +127,12 @@
         <height>332</height>
        </rect>
       </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>1</verstretch>
+       </sizepolicy>
+      </property>
       <layout class="QGridLayout" name="gridLayout_11">
        <property name="leftMargin">
         <number>1</number>
@@ -217,6 +223,9 @@
           </property>
           <item row="5" column="1">
            <widget class="QComboBox" name="representationCombo">
+            <property name="currentIndex">
+             <number>-1</number>
+            </property>
             <item>
              <property name="text">
               <string>Point</string>

--- a/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
@@ -223,20 +223,6 @@ void VSInfoWidget::setFilter(VSAbstractFilter* filter, VSAbstractFilterWidget* f
 
   updateFilterInfo();
   updateViewSettingInfo();
-
-  // Update widget size
-  QSize preferredSize = sizeHint();
-  int newWidth;
-  if(parentWidget())
-  {
-    newWidth = std::min(width(), parentWidget()->width());
-  }
-  else
-  {
-    newWidth = width();
-  }
-  preferredSize.setWidth(width());
-  resize(preferredSize);
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VisualFilterWidgets/UI_Files/VSClipFilterWidget.ui
+++ b/SIMPLVtkLib/Visualization/VisualFilterWidgets/UI_Files/VSClipFilterWidget.ui
@@ -44,7 +44,7 @@
    <item>
     <widget class="QWidget" name="clipTypeWidget" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -87,7 +87,7 @@
       <item>
        <widget class="QComboBox" name="clipTypeComboBox">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>


### PR DESCRIPTION
* Removed resizing code from VSInfoWidget::setFilter.

* VSInfoWidget's viewSettingsWidget is now set to vertically expand

* VSClipFilter had its widgets changed from horizontally expanding to MinimumExpanding or Preferred.