### PR TITLE
Feature/Image Slice Angle

### DIFF
--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -662,7 +662,7 @@ void VSFilterViewSettings::setupImageActors()
   vtkImageSliceMapper* mapper = vtkImageSliceMapper::New();
   mapper->SetInputConnection(m_Filter->getOutputPort());
   mapper->SliceAtFocalPointOn();
-  mapper->SliceFacesCameraOn();
+  mapper->SliceFacesCameraOff();
   m_Mapper = mapper;
 
   vtkImageSlice* actor = vtkImageSlice::New();


### PR DESCRIPTION
Fixed a bug where Image slices would disappear when the camera was oriented at least 45 degrees from the slice's normal.