### PR TITLE
Feature/mac crash multi thread

### DIFF
--- a/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
@@ -54,8 +54,11 @@ VSConcurrentImport::VSConcurrentImport(VSController* controller)
 , m_WrappedDcLock(1)
 {
   m_UnappliedDataFilters.clear();
-  connect(this, SIGNAL(importedFilter(VSAbstractFilter*, bool)),
-    controller->getFilterModel(), SLOT(addFilter(VSAbstractFilter*, bool)));
+  if(controller && controller->getFilterModel())
+  {
+    connect(this, SIGNAL(importedFilter(VSAbstractFilter*, bool)),
+      controller->getFilterModel(), SLOT(addFilter(VSAbstractFilter*, bool)));
+  }
 
   int threadsUsed = 2;
   m_ThreadCount = QThreadPool::globalInstance()->maxThreadCount();
@@ -171,6 +174,11 @@ void VSConcurrentImport::importDataContainer(VSFileNameFilter* fileFilter)
   while (m_ImportDataContainerOrder.size() > 0)
   {
     m_ImportDataContainerOrderLock.acquire();
+    if(m_ImportDataContainerOrder.size() <= 0)
+    {
+      m_ImportDataContainerOrderLock.release();
+      break;
+    }
     DataContainer::Pointer dc = m_ImportDataContainerOrder.front();
     m_ImportDataContainerOrder.pop_front();
 

--- a/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
@@ -163,6 +163,10 @@ void VSConcurrentImport::partialWrappingThreadFinished()
     emit blockRender(false);
     m_FilterLock.release();
 
+    m_UnappliedDataFilterLock.acquire();
+    emit applyingDataFilters(m_UnappliedDataFilters.size());
+    m_UnappliedDataFilterLock.release();
+
     // Apply the filters only after all DataContainers for all files have been wrapped
     if(m_WrappedList.size() == 0)
     {
@@ -208,7 +212,6 @@ void VSConcurrentImport::importDataContainer(VSFileNameFilter* fileFilter)
 void VSConcurrentImport::applyDataFilters()
 {
   m_UnappliedDataFilterLock.acquire();
-  emit applyingDataFilters(m_UnappliedDataFilters.size());
   while(m_UnappliedDataFilters.size() > 0)
   {
     VSSIMPLDataContainerFilter* filter = m_UnappliedDataFilters.front();

--- a/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.h
@@ -91,9 +91,19 @@ signals:
   void blockRender(bool block = true);
   void applyingDataFilters(int count);
   void dataFilterApplied(int num);
+  void finishedWrappingFilter(VSSIMPLDataContainerFilter* filter);
 
 protected slots:
+  /**
+  * @brief partialWrappingThreadFinished
+  */
   void partialWrappingThreadFinished();
+
+  /**
+  * @brief applyFilter
+  * @param filter
+  */
+  void applyDataFilter(VSSIMPLDataContainerFilter* filter);
 
 protected:
   /**

--- a/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.h
@@ -129,6 +129,8 @@ private:
   QSemaphore m_UnappliedDataFilterLock;
   QSemaphore m_FilterLock;
   QSemaphore m_WrappedDcLock;
+  QSemaphore m_ThreadCountLock;
+  QSemaphore m_AppliedFilterCountLock;
   int m_NumOfFinishedImportDataContainerThreads = 0;
   std::list<SIMPLVtkBridge::WrappedDataContainerPtr> m_WrappedDataContainers;
   VSFileNameFilter* m_FileNameFilter = nullptr;

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -767,7 +767,7 @@ void VSFilterViewSettings::setupDataSetActors()
     }
     else
     {
-      int currentComponent = m_ActiveComponent;
+      //int currentComponent = m_ActiveComponent;
       setActiveArrayIndex(m_ActiveArray);
       setActiveComponentIndex(m_ActiveComponent);
     }

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.cpp
@@ -55,6 +55,7 @@
 VSSIMPLDataContainerFilter::VSSIMPLDataContainerFilter(SIMPLVtkBridge::WrappedDataContainerPtr wrappedDataContainer, VSAbstractFilter *parent)
 : VSAbstractDataFilter()
 , m_WrappedDataContainer(wrappedDataContainer)
+, m_ApplyLock(1)
 {
   createFilter();
 
@@ -227,9 +228,15 @@ QString VSSIMPLDataContainerFilter::getToolTip() const
 // -----------------------------------------------------------------------------
 void VSSIMPLDataContainerFilter::apply()
 {
-  SIMPLVtkBridge::FinishWrappingDataContainerStruct(m_WrappedDataContainer);
-  m_TrivialProducer->SetOutput(m_WrappedDataContainer->m_DataSet);
-  emit dataImported();
+  // Do not lock the main thread trying to apply a filter that is already being applied.
+  if(m_ApplyLock.tryAcquire())
+  {
+    SIMPLVtkBridge::FinishWrappingDataContainerStruct(m_WrappedDataContainer);
+    m_TrivialProducer->SetOutput(m_WrappedDataContainer->m_DataSet);
+    m_ApplyLock.release();
+
+    emit dataImported();
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.cpp
@@ -231,11 +231,23 @@ void VSSIMPLDataContainerFilter::apply()
   // Do not lock the main thread trying to apply a filter that is already being applied.
   if(m_ApplyLock.tryAcquire())
   {
-    SIMPLVtkBridge::FinishWrappingDataContainerStruct(m_WrappedDataContainer);
     m_TrivialProducer->SetOutput(m_WrappedDataContainer->m_DataSet);
     m_ApplyLock.release();
 
     emit dataImported();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSSIMPLDataContainerFilter::finishWrapping()
+{
+  // Do not lock the main thread trying to apply a filter that is already being applied.
+  if(m_ApplyLock.tryAcquire())
+  {
+    SIMPLVtkBridge::FinishWrappingDataContainerStruct(m_WrappedDataContainer);
+    m_ApplyLock.release();
   }
 }
 

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.h
@@ -110,6 +110,11 @@ public:
   void apply();
 
   /**
+  * @brief finishWrapping
+  */
+  void finishWrapping();
+
+  /**
   * @brief Returns the WrappedDataContainerPtr used by the filter
   * @return
   */

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <QtCore/QSemaphore>
 #include <QtWidgets/QWidget>
 
 #include <vtkTrivialProducer.h>
@@ -143,4 +144,5 @@ protected:
 private:
   SIMPLVtkBridge::WrappedDataContainerPtr m_WrappedDataContainer = nullptr;
   VTK_PTR(vtkTrivialProducer) m_TrivialProducer = nullptr;
+  QSemaphore m_ApplyLock;
 };


### PR DESCRIPTION
* Fixed two crash-inducing bugs on Mac due to multithreading issues.  The first bug was caused by accessing invalid memory addresses, and the second from calling VTK methods in other threads. Windows handled both of these relatively fine, but Mac would crash for both.