### PR TITLE
Feature/Dream3D Pipelines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,9 @@ target_compile_definitions(SIMPLVtkLib PRIVATE -DQT_CORE_LIB)
 # LibraryProperties( SIMPLVtkLib ${EXE_DEBUG_EXTENSION})
 target_link_libraries(SIMPLVtkLib ${SIMPLVtkLib_LINK_LIBRARIES} )
 
+set_target_properties(SIMPLVtkLib
+                          PROPERTIES FOLDER SIMPLVtkLib)
+
 set(install_dir "tools")
 set(lib_install_dir "lib")
 if(WIN32)

--- a/SIMPLVtkLib/QtWidgets/SourceList.cmake
+++ b/SIMPLVtkLib/QtWidgets/SourceList.cmake
@@ -6,6 +6,7 @@ set(${PROJECT_NAME}_QtWidgets_HDRS
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSInfoWidget.h
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSInteractorStyleFilterCamera.h
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSMainWidget.h
+  ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSMainWidget2.h
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.h
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSTransformWidget.h
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSViewWidget.h
@@ -19,6 +20,7 @@ set(${PROJECT_NAME}_QtWidgets_SRCS
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSInfoWidget.cpp
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSInteractorStyleFilterCamera.cpp
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSMainWidget.cpp
+  ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSMainWidget2.cpp
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSMainWidgetBase.cpp
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSTransformWidget.cpp
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/VSViewWidget.cpp
@@ -28,6 +30,7 @@ set(${PROJECT_NAME}_QtWidgets_SRCS
 set(${PROJECT_NAME}_QtWidgets_UIS
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/UI_Files/VSInfoWidget.ui
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/UI_Files/VSMainWidget.ui
+  ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/UI_Files/VSMainWidget2.ui
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/UI_Files/VSTransformWidget.ui
   ${${PROJECT_NAME}_SOURCE_DIR}/SIMPLVtkLib/QtWidgets/UI_Files/VSViewWidget.ui
 )

--- a/SIMPLVtkLib/QtWidgets/UI_Files/VSMainWidget2.ui
+++ b/SIMPLVtkLib/QtWidgets/UI_Files/VSMainWidget2.ui
@@ -1,0 +1,518 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>VSMainWidget2</class>
+ <widget class="QWidget" name="VSMainWidget2">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>912</width>
+    <height>555</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>SIMPL Visualization Window</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>1</number>
+   </property>
+   <property name="topMargin">
+    <number>1</number>
+   </property>
+   <property name="rightMargin">
+    <number>1</number>
+   </property>
+   <property name="bottomMargin">
+    <number>1</number>
+   </property>
+   <property name="horizontalSpacing">
+    <number>1</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>4</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QWidget" name="menuWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout" name="menuLayout">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="toggleFiltersButton">
+        <property name="toolTip">
+         <string>Show Filter Info</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../Resources/VtkSIMPL.qrc">
+          <normaloff>:/icons/pqGear.png</normaloff>:/icons/pqGear.png</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="filterBtnWidget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="filterBtnLayout">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="clipBtn">
+           <property name="toolTip">
+            <string>Add Clip Filter</string>
+           </property>
+           <property name="statusTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqClip.png</normaloff>:/icons/pqClip.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="sliceBtn">
+           <property name="toolTip">
+            <string>Add Slice Filter</string>
+           </property>
+           <property name="statusTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqSlice.png</normaloff>:/icons/pqSlice.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="thresholdBtn">
+           <property name="toolTip">
+            <string>Add Threshold Filter</string>
+           </property>
+           <property name="statusTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqThreshold.png</normaloff>:/icons/pqThreshold.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>1</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QWidget" name="cameraAxisWidget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="cameraAxisLayout">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="cameraXpBtn">
+           <property name="toolTip">
+            <string extracomment="X+">Set view direction to +X</string>
+           </property>
+           <property name="statusTip">
+            <string>Set view direction to +X</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqXplus.png</normaloff>:/icons/pqXplus.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="cameraXmBtn">
+           <property name="toolTip">
+            <string extracomment="X-">Set view direction to -X</string>
+           </property>
+           <property name="statusTip">
+            <string>Set view direction to -X</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqXminus.png</normaloff>:/icons/pqXminus.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="cameraYpBtn">
+           <property name="toolTip">
+            <string extracomment="Y+">Set view direction to +Y</string>
+           </property>
+           <property name="statusTip">
+            <string>Set view direction to +Y</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqYplus.png</normaloff>:/icons/pqYplus.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="cameraYmBtn">
+           <property name="toolTip">
+            <string extracomment="Y-">Set view direction to -Y</string>
+           </property>
+           <property name="statusTip">
+            <string>Set view direction to -Y</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqYminus.png</normaloff>:/icons/pqYminus.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="cameraZpBtn">
+           <property name="toolTip">
+            <string extracomment="Z+">Set view direction to +Z</string>
+           </property>
+           <property name="statusTip">
+            <string>Set view direction to +Z</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqZplus.png</normaloff>:/icons/pqZplus.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="cameraZmBtn">
+           <property name="toolTip">
+            <string extracomment="Z-">Set view direction to -Z</string>
+           </property>
+           <property name="statusTip">
+            <string>Set view direction to -Z</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../Resources/VtkSIMPL.qrc">
+             <normaloff>:/icons/pqZminus.png</normaloff>:/icons/pqZminus.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QSplitter" name="visualizationSplitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QSplitter" name="filterSplitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <widget class="VSFilterView" name="filterView">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>250</height>
+        </size>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SingleSelection</enum>
+       </property>
+      </widget>
+      <widget class="VSInfoWidget" name="infoWidget" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </widget>
+     <widget class="VSViewWidget" name="viewWidget" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>1</verstretch>
+       </sizepolicy>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QWidget" name="progressWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <item row="0" column="0">
+       <spacer name="progressSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>450</width>
+          <height>15</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="1">
+       <widget class="QProgressBar" name="progressBar">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <property name="textVisible">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>VSFilterView</class>
+   <extends>QTreeView</extends>
+   <header>VSFilterView.h</header>
+  </customwidget>
+  <customwidget>
+   <class>VSInfoWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">VSInfoWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>VSViewWidget</class>
+   <extends>QWidget</extends>
+   <header>VSViewWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../../Resources/VtkSIMPL.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSAbstractViewWidget.cpp
@@ -68,6 +68,8 @@ void VSAbstractViewWidget::copyFilters(VSFilterViewSettings::Map filters)
     VSFilterViewSettings* viewSettings = new VSFilterViewSettings(*(iter->second));
     m_FilterViewSettings[filter] = viewSettings;
 
+    connect(filter, &VSAbstractFilter::removeFilter, this, [=] { filterRemoved(filter); });
+
     connect(viewSettings, SIGNAL(filterAdded(VSAbstractFilter*)), this, SLOT(filterAdded(VSAbstractFilter*)));
     connect(viewSettings, SIGNAL(filterRemoved(VSAbstractFilter*)), this, SLOT(filterRemoved(VSAbstractFilter*)));
 
@@ -129,7 +131,7 @@ void VSAbstractViewWidget::filterRemoved(VSAbstractFilter* filter)
     return;
   }
 
-  VSFilterViewSettings* viewSettings = getFilterViewSettings(filter);
+  VSFilterViewSettings* viewSettings = m_FilterViewSettings[filter];
   if(viewSettings)
   {
     setFilterVisibility(viewSettings, false);
@@ -232,6 +234,8 @@ VSFilterViewSettings* VSAbstractViewWidget::createFilterViewSettings(VSAbstractF
   }
 
   VSFilterViewSettings* viewSettings = new VSFilterViewSettings(filter);
+
+  connect(filter, &VSAbstractFilter::removeFilter, this, [=] { filterRemoved(filter); });
 
   connect(viewSettings, SIGNAL(visibilityChanged(VSFilterViewSettings*, bool)), this, SLOT(setFilterVisibility(VSFilterViewSettings*, bool)));
   connect(viewSettings, SIGNAL(activeArrayIndexChanged(VSFilterViewSettings*, int)), this, SLOT(setFilterArrayIndex(VSFilterViewSettings*, int)));

--- a/SIMPLVtkLib/QtWidgets/VSMainWidget2.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidget2.cpp
@@ -1,0 +1,353 @@
+/* ============================================================================
+ * Copyright (c) 2009-2017 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "VSMainWidget2.h"
+
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSClipFilter.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSCropFilter.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSMaskFilter.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSSliceFilter.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSTextFilter.h"
+#include "SIMPLVtkLib/Visualization/VisualFilters/VSThresholdFilter.h"
+
+#include "ui_VSMainWidget2.h"
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+class VSMainWidget2::vsInternals : public Ui::VSMainWidget2
+{
+public:
+  vsInternals()
+  {
+  }
+};
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+VSMainWidget2::VSMainWidget2(QWidget* parent)
+: VSMainWidgetBase(parent)
+, m_Internals(new vsInternals())
+{
+  m_Internals->setupUi(this);
+
+  VSAbstractViewWidget* viewWidget = m_Internals->viewWidget;
+  viewWidget->setController(getController());
+  connectViewWidget(viewWidget);
+  setActiveView(viewWidget);
+
+  // Set the VSFilterView and VSInfoWidget
+  setFilterView(m_Internals->filterView);
+  setInfoWidget(m_Internals->infoWidget);
+  showFilterView(false);
+
+  createFilterMenu();
+  connectSlots();
+  setCurrentFilter(nullptr);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::connectSlots()
+{
+  // Filter Slots
+  connect(m_Internals->clipBtn, SIGNAL(clicked()), m_ActionAddClip, SLOT(trigger()));
+  connect(m_Internals->sliceBtn, SIGNAL(clicked()), m_ActionAddSlice, SLOT(trigger()));
+  connect(m_Internals->thresholdBtn, SIGNAL(clicked()), m_ActionAddThreshold, SLOT(trigger()));
+
+  // Camera Slots
+  connect(m_Internals->cameraXpBtn, SIGNAL(clicked()), this, SLOT(activeCameraXPlus()));
+  connect(m_Internals->cameraYpBtn, SIGNAL(clicked()), this, SLOT(activeCameraYPlus()));
+  connect(m_Internals->cameraZpBtn, SIGNAL(clicked()), this, SLOT(activeCameraZPlus()));
+  connect(m_Internals->cameraXmBtn, SIGNAL(clicked()), this, SLOT(activeCameraXMinus()));
+  connect(m_Internals->cameraYmBtn, SIGNAL(clicked()), this, SLOT(activeCameraYMinus()));
+  connect(m_Internals->cameraZmBtn, SIGNAL(clicked()), this, SLOT(activeCameraZMinus()));
+
+  connect(getController(), &VSController::filterAdded, this, [=] { renderAll(); });
+  connect(getController(), &VSController::dataImported, this, [=] { resetCamera(); });
+  connect(getController(), SIGNAL(applyingDataFilters(int)), this, SLOT(importNumFilters(int)));
+  connect(getController(), SIGNAL(dataFilterApplied(int)), this, SLOT(importedFilterNum(int)));
+
+  connect(m_Internals->toggleFiltersButton, &QPushButton::toggled, [=](bool checked) { showFilterView(checked); });
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::showFilterView(bool visible)
+{
+  m_Internals->filterSplitter->setVisible(visible);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::renderAll()
+{
+  QVector<VSAbstractViewWidget*> viewWidgets = getAllViewWidgets();
+  for(auto iter = viewWidgets.begin(); iter != viewWidgets.end(); iter++)
+  {
+    VSVisualizationWidget* visualizationWidget = (*iter)->getVisualizationWidget();
+    if(visualizationWidget)
+    {
+      // Render the VTK widget
+      visualizationWidget->render();
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::resetCamera()
+{
+  QVector<VSAbstractViewWidget*> viewWidgets = getAllViewWidgets();
+  for(VSAbstractViewWidget* viewWidget : viewWidgets)
+  {
+    viewWidget->resetCamera();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::setActiveView(VSAbstractViewWidget* viewWidget)
+{
+  VSMainWidgetBase::setActiveView(viewWidget);
+
+  if(getActiveViewWidget() != nullptr)
+  {
+    m_Internals->cameraXmBtn->setEnabled(true);
+    m_Internals->cameraXpBtn->setEnabled(true);
+    m_Internals->cameraYmBtn->setEnabled(true);
+    m_Internals->cameraYpBtn->setEnabled(true);
+    m_Internals->cameraZmBtn->setEnabled(true);
+    m_Internals->cameraZpBtn->setEnabled(true);
+  }
+  else
+  {
+    m_Internals->cameraXmBtn->setDisabled(true);
+    m_Internals->cameraXpBtn->setDisabled(true);
+    m_Internals->cameraYmBtn->setDisabled(true);
+    m_Internals->cameraYpBtn->setDisabled(true);
+    m_Internals->cameraZmBtn->setDisabled(true);
+    m_Internals->cameraZpBtn->setDisabled(true);
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::setCurrentFilter(VSAbstractFilter* filter)
+{
+  VSMainWidgetBase::setCurrentFilter(filter);
+
+  // Check if each Filter Type can be added
+  // Clip Filter
+  bool enableClip = VSClipFilter::compatibleWithParent(filter);
+  m_Internals->clipBtn->setEnabled(enableClip);
+  m_ActionAddClip->setEnabled(enableClip);
+
+  // Slice
+  bool enableSlice = VSSliceFilter::compatibleWithParent(filter);
+  m_Internals->sliceBtn->setEnabled(enableSlice);
+  m_ActionAddSlice->setEnabled(enableSlice);
+
+  // Crop Filter
+  bool enableCrop = VSCropFilter::compatibleWithParent(filter);
+  m_ActionAddCrop->setEnabled(enableCrop);
+
+  // Mask
+  bool enableMask = VSMaskFilter::compatibleWithParent(filter);
+  m_ActionAddMask->setEnabled(enableMask);
+
+  // Threshold
+  bool enableThreshold = VSThresholdFilter::compatibleWithParent(filter);
+  m_Internals->thresholdBtn->setEnabled(enableThreshold);
+  m_ActionAddThreshold->setEnabled(enableThreshold);
+
+  // Text
+  bool enableText = VSTextFilter::compatibleWithParent(filter);
+  m_ActionAddText->setEnabled(enableText);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::activeCameraXPlus()
+{
+  VSAbstractViewWidget* activeView = getActiveViewWidget();
+
+  if(activeView && activeView->getVisualizationWidget())
+  {
+    activeView->getVisualizationWidget()->camXPlus();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::activeCameraYPlus()
+{
+  VSAbstractViewWidget* activeView = getActiveViewWidget();
+
+  if(activeView && activeView->getVisualizationWidget())
+  {
+    activeView->getVisualizationWidget()->camYPlus();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::activeCameraZPlus()
+{
+  VSAbstractViewWidget* activeView = getActiveViewWidget();
+
+  if(activeView && activeView->getVisualizationWidget())
+  {
+    activeView->getVisualizationWidget()->camZPlus();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::activeCameraXMinus()
+{
+  VSAbstractViewWidget* activeView = getActiveViewWidget();
+
+  if(activeView && activeView->getVisualizationWidget())
+  {
+    activeView->getVisualizationWidget()->camXMinus();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::activeCameraYMinus()
+{
+  VSAbstractViewWidget* activeView = getActiveViewWidget();
+
+  if(activeView && activeView->getVisualizationWidget())
+  {
+    activeView->getVisualizationWidget()->camYMinus();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::activeCameraZMinus()
+{
+  VSAbstractViewWidget* activeView = getActiveViewWidget();
+
+  if(activeView && activeView->getVisualizationWidget())
+  {
+    activeView->getVisualizationWidget()->camZMinus();
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QMenu* VSMainWidget2::getFilterMenu()
+{
+  return m_FilterMenu;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::createFilterMenu()
+{
+  // Create Actions
+  m_ActionAddClip = new QAction("Clip Filter");
+  connect(m_ActionAddClip, SIGNAL(triggered()), this, SLOT(createClipFilter()));
+
+  m_ActionAddCrop = new QAction("Crop Filter");
+  connect(m_ActionAddCrop, SIGNAL(triggered()), this, SLOT(createCropFilter()));
+
+  m_ActionAddSlice = new QAction("Slice Filter");
+  connect(m_ActionAddSlice, SIGNAL(triggered()), this, SLOT(createSliceFilter()));
+
+  m_ActionAddThreshold = new QAction("Threshold Filter");
+  connect(m_ActionAddThreshold, SIGNAL(triggered()), this, SLOT(createThresholdFilter()));
+
+  m_ActionAddMask = new QAction("Mask Filter");
+  connect(m_ActionAddMask, SIGNAL(triggered()), this, SLOT(createMaskFilter()));
+
+  m_ActionAddText = new QAction("Text Filter");
+  connect(m_ActionAddText, SIGNAL(triggered()), this, SLOT(createTextFilter()));
+
+  // Create Menu
+  m_FilterMenu = new QMenu("Filters", this);
+  m_FilterMenu->addAction(m_ActionAddClip);
+  m_FilterMenu->addAction(m_ActionAddSlice);
+  m_FilterMenu->addAction(m_ActionAddCrop);
+  m_FilterMenu->addAction(m_ActionAddThreshold);
+  m_FilterMenu->addAction(m_ActionAddMask);
+
+  m_FilterMenu->addSeparator();
+
+  m_FilterMenu->addAction(m_ActionAddText);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::importNumFilters(int max)
+{
+  m_Internals->progressBar->setMaximum(max);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void VSMainWidget2::importedFilterNum(int value)
+{
+  int maxValue = m_Internals->progressBar->maximum();
+  if(value == maxValue)
+  {
+    m_Internals->progressBar->setValue(0);
+  }
+  else
+  {
+    m_Internals->progressBar->setValue(value);
+  }
+}

--- a/SIMPLVtkLib/QtWidgets/VSMainWidget2.h
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidget2.h
@@ -1,0 +1,171 @@
+/* ============================================================================
+ * Copyright (c) 2009-2017 BlueQuartz Software, LLC
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+ * contributors may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The code contained herein was partially funded by the followig contracts:
+ *    United States Air Force Prime Contract FA8650-07-D-5800
+ *    United States Air Force Prime Contract FA8650-10-D-5210
+ *    United States Prime Contract Navy N00173-07-C-2068
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <QtWidgets/QAction>
+#include <QtWidgets/QMenu>
+
+#include "SVWidgetsLib/Widgets/PopUpWidget.h"
+
+#include "SIMPLVtkLib/QtWidgets/VSMainWidgetBase.h"
+
+#include "SIMPLVtkLib/SIMPLVtkLib.h"
+
+/**
+ * @class VSMainWidget2 VSMainWidget2.h SIMPLVtkLib/QtWidgets/VSMainWidget2.h
+ * @brief This class works as SIMPLVtkLib's main widget that displays information
+ * relating to the stored VSController. It subclasses from VSMainWidgetBase for
+ * most of its implementation but is provided with a UI file for formatting the
+ * widget.  This widget includes its own VSInfoWidget and VSFilterView
+ */
+class SIMPLVtkLib_EXPORT VSMainWidget2 : public VSMainWidgetBase
+{
+  Q_OBJECT
+
+public:
+  /**
+   * @brief Constructor
+   * @param parent
+   */
+  VSMainWidget2(QWidget* parent = nullptr);
+
+  /**
+   * @brief Deconstructor
+   */
+  virtual ~VSMainWidget2() = default;
+
+  /**
+   * @brief Returns a QMenu with all the Add Filter actions
+   * @return
+   */
+  QMenu* getFilterMenu();
+
+protected:
+  /**
+   * @brief Connect Qt signals and slots
+   */
+  virtual void connectSlots() override;
+
+  /**
+   * @brief Creates the filter menu
+   */
+  virtual void createFilterMenu();
+
+  /**
+   * @brief Sets the visibility of the VSFilterView and VSInfoWidget as a popup
+   * @param visible
+   */
+  void showFilterView(bool visible);
+
+protected slots:
+  /**
+   * @brief Notifies change in the active VSAbstractViewWidget
+   * @param viewWidget
+   */
+  void setActiveView(VSAbstractViewWidget* viewWidget) override;
+
+  /**
+   * @brief setCurrentFilter
+   * @param filter
+   */
+  void setCurrentFilter(VSAbstractFilter* filter) override;
+
+  /**
+   * @brief Sets the active view camera position to the X+ axis
+   */
+  void activeCameraXPlus();
+
+  /**
+   * @brief Sets the active view camera position to the Y+ axis
+   */
+  void activeCameraYPlus();
+
+  /**
+   * @brief Sets the active view camera position to the Z+ axis
+   */
+  void activeCameraZPlus();
+
+  /**
+   * @brief Sets the active view camera position to the X- axis
+   */
+  void activeCameraXMinus();
+
+  /**
+   * @brief Sets the active view camera position to the Y- axis
+   */
+  void activeCameraYMinus();
+
+  /**
+   * @brief Sets the active view camera position to the Z- axis
+   */
+  void activeCameraZMinus();
+
+  /**
+   * @brief Renders all VSViewWidgets
+   */
+  void renderAll();
+
+  /**
+   * @brief Resets all render view cameras
+   */
+  void resetCamera();
+
+  /**
+   * @brief Sets the progress bar's maximum value based on the
+   * number of filters being imported.
+   * @param max
+   */
+  void importNumFilters(int max);
+
+  /**
+   * @brief Sets the progress bar's current value based on the
+   * number of filters already imported.
+   * @param value
+   */
+  void importedFilterNum(int value);
+
+private:
+  class vsInternals;
+  vsInternals* m_Internals;
+
+  QMenu* m_FilterMenu = nullptr;
+  QAction* m_ActionAddText = nullptr;
+  QAction* m_ActionAddClip = nullptr;
+  QAction* m_ActionAddCrop = nullptr;
+  QAction* m_ActionAddSlice = nullptr;
+  QAction* m_ActionAddMask = nullptr;
+  QAction* m_ActionAddThreshold = nullptr;
+};

--- a/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
@@ -171,17 +171,15 @@ void VSConcurrentImport::partialWrappingThreadFinished()
   if(m_ThreadsRemaining <= 0)
   {
     m_ThreadCountLock.release();
+
+    QVector<VSAbstractFilter*> childFilters = m_DataParentFilter->getChildren();
     for(SIMPLVtkBridge::WrappedDataContainerPtr wrappedDc : m_WrappedDataContainers)
     {
       VSSIMPLDataContainerFilter* filter = nullptr;
-      if(m_LoadType == LoadType::Import)
+      
+      // Reload existing data and search for old DataContainers that no longer exist
+      if(m_LoadType == LoadType::Reload)
       {
-        filter = new VSSIMPLDataContainerFilter(wrappedDc, m_DataParentFilter);
-        m_Controller->getFilterModel()->addFilter(filter, false);
-      }
-      else
-      {
-        QVector<VSAbstractFilter*> childFilters = m_DataParentFilter->getChildren();
         for(int i = 0; i < childFilters.size(); i++)
         {
           VSAbstractFilter* childFilter = childFilters[i];
@@ -194,14 +192,37 @@ void VSConcurrentImport::partialWrappingThreadFinished()
           if(filter)
           {
             filter->setWrappedDataContainer(wrappedDc);
+            // Remove from the list of childFilters
+            int index = childFilters.indexOf(filter);
+            childFilters.remove(index);
           }
         }
       }
 
-      // Attempting to run applyDataFilters requires the QSemaphore to lock when modifying this vector
-      m_UnappliedDataFilterLock.acquire();
-      m_UnappliedDataFilters.push_back(filter);
-      m_UnappliedDataFilterLock.release();
+      // Import data if it was not there to reload
+      if(m_LoadType == LoadType::Import || nullptr == filter)
+      {
+        filter = new VSSIMPLDataContainerFilter(wrappedDc, m_DataParentFilter);
+        m_Controller->getFilterModel()->addFilter(filter, false);
+      }
+
+      // Do not append a nullptr to the list to be applied later
+      if(filter)
+      {
+        // Attempting to run applyDataFilters requires the QSemaphore to lock when modifying this vector
+        m_UnappliedDataFilterLock.acquire();
+        m_UnappliedDataFilters.push_back(filter);
+        m_UnappliedDataFilterLock.release();
+      }
+    }
+
+    // When reloading, delete any extra data that no longer exists
+    if(m_LoadType == LoadType::Reload)
+    {
+      for(VSAbstractFilter* filter : childFilters)
+      {
+        filter->deleteFilter();
+      }
     }
 
     // Select the last filter

--- a/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
@@ -219,9 +219,10 @@ void VSConcurrentImport::partialWrappingThreadFinished()
     // When reloading, delete any extra data that no longer exists
     if(m_LoadType == LoadType::Reload)
     {
-      for(VSAbstractFilter* filter : childFilters)
+      int count = childFilters.size();
+      for(int i = 0; i < count; i++)
       {
-        filter->deleteFilter();
+        childFilters[i]->deleteFilter();
       }
     }
 

--- a/SIMPLVtkLib/Visualization/Controllers/VSController.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSController.cpp
@@ -112,7 +112,7 @@ void VSController::importPipelineOutput(FilterPipeline::Pointer pipeline, DataCo
 // -----------------------------------------------------------------------------
 void VSController::reloadPipelineOutput(FilterPipeline::Pointer pipeline, DataContainerArray::Pointer dca)
 {
-  VSPipelineFilter* parentFilter = dynamic_cast<VSPipelineFilter*>(getFilterModel()->getPipelineFilter(pipeline->getName()));
+  VSPipelineFilter* parentFilter = dynamic_cast<VSPipelineFilter*>(getFilterModel()->getPipelineFilter(pipeline));
   if(parentFilter)
   {
     m_ImportObject->setLoadType(VSConcurrentImport::LoadType::Reload);

--- a/SIMPLVtkLib/Visualization/Controllers/VSController.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSController.cpp
@@ -112,17 +112,18 @@ void VSController::importPipelineOutput(FilterPipeline::Pointer pipeline, DataCo
 // -----------------------------------------------------------------------------
 void VSController::reloadPipelineOutput(FilterPipeline::Pointer pipeline, DataContainerArray::Pointer dca)
 {
-  VSAbstractFilter* parentFilter = getFilterModel()->getPipelineFilter(pipeline->getName());
+  VSPipelineFilter* parentFilter = dynamic_cast<VSPipelineFilter*>(getFilterModel()->getPipelineFilter(pipeline->getName()));
   if(parentFilter)
   {
     m_ImportObject->setLoadType(VSConcurrentImport::LoadType::Reload);
+    m_ImportObject->addDataContainerArray(parentFilter, dca);
   }
   else
   {
     m_ImportObject->setLoadType(VSConcurrentImport::LoadType::Import);
+    m_ImportObject->addDataContainerArray(pipeline, dca);
   }
-  
-  m_ImportObject->addDataContainerArray(pipeline, dca);
+
   m_ImportObject->run();
 }
 

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterModel.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterModel.cpp
@@ -225,9 +225,9 @@ VSAbstractFilter* VSFilterModel::getPipelineFilter(QString pipelineName)
 // -----------------------------------------------------------------------------
 void VSFilterModel::updateModelForView(VSFilterViewSettings::Map viewSettings)
 {
-  for(auto iter = viewSettings.begin(); iter != viewSettings.end(); iter++)
+  for(auto iter : viewSettings)
   {
-    VSFilterViewSettings* settings = iter->second;
+    VSFilterViewSettings* settings = iter.second;
     VSAbstractFilter* filter = settings->getFilter();
     filter->setCheckState(settings->isVisible() ? Qt::Checked : Qt::Unchecked);
   }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
@@ -393,6 +393,11 @@ protected:
   void connectFilter(VSAbstractFilter* filter);
 
   /**
+   * @brief Handles the target filter being deleted.
+   */
+  void filterDeleted();
+
+  /**
    * @brief Returns the array at the given index
    * @param index
    * @return

--- a/SIMPLVtkLib/Visualization/Controllers/VSLookupTableController.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSLookupTableController.cpp
@@ -199,6 +199,16 @@ void VSLookupTableController::copy(const VSLookupTableController& other)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+VSLookupTableController* VSLookupTableController::deepCopy()
+{
+  VSLookupTableController* other = new VSLookupTableController();
+  other->copy(*this);
+  return other;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 void VSLookupTableController::invert()
 {
   double minRange = m_Range[0];

--- a/SIMPLVtkLib/Visualization/Controllers/VSLookupTableController.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSLookupTableController.h
@@ -100,6 +100,12 @@ public:
   void copy(const VSLookupTableController& other);
 
   /**
+   * @brief Returns a pointer to a VSLookupTableController with all the same values
+   * @return
+   */
+  VSLookupTableController* deepCopy();
+
+  /**
    * @brief Inverts the placement values for colors in the lookup table
    */
   void invert();

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.cpp
@@ -74,6 +74,8 @@ VSAbstractFilter::VSAbstractFilter()
 // -----------------------------------------------------------------------------
 void VSAbstractFilter::deleteFilter()
 {
+  emit removeFilter();
+
   if(getParentFilter())
   {
     getParentFilter()->removeChild(this);

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSAbstractFilter.h
@@ -251,6 +251,7 @@ signals:
   void updatedOutput();
   void transformChanged();
   void errorGenerated(const QString& title, const QString& msg, const int& errorCode);
+  void removeFilter();
 
 protected slots:
   /**


### PR DESCRIPTION
* Added support for importing and reloading FilterPipelines from SIMPLib

* When reloading DataContainers, delete any visualization filters handling DataContainers that no longer exist.

* Added VSMainWidget2 based on VSMainWidget but with an additional button to toggle its own created VSInfoWidget and VSFilterView.

* Nested the SIMPLVtkLib project inside a folder of the same name in Visual Studio Solution Explorer to be consistent with other DREAM.3D libraries.