### PR TITLE
Fixed the Outline Only option in the montage dialogs

### DIFF
--- a/SIMPLVtkLib/Dialogs/ImportDREAM3DMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportDREAM3DMontageDialog.cpp
@@ -111,7 +111,7 @@ void ImportDREAM3DMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
-  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+  setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
   checkComplete();
 }

--- a/SIMPLVtkLib/Dialogs/ImportDREAM3DMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportDREAM3DMontageDialog.cpp
@@ -111,6 +111,8 @@ void ImportDREAM3DMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
+  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+
   checkComplete();
 }
 

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
@@ -98,7 +98,7 @@ void ImportFijiMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
-  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+  setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
   checkComplete();
 }

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
@@ -98,6 +98,8 @@ void ImportFijiMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
+  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+
   checkComplete();
 }
 

--- a/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
@@ -96,7 +96,7 @@ void ImportGenericMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
-  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+  setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
   checkComplete();
 }

--- a/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
@@ -96,6 +96,8 @@ void ImportGenericMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
+  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+
   checkComplete();
 }
 

--- a/SIMPLVtkLib/Dialogs/ImportRobometMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportRobometMontageDialog.cpp
@@ -91,6 +91,8 @@ void ImportRobometMontageDialog::setupGui()
 
   connectSignalsSlots();
 
+  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+
   checkComplete();
 }
 

--- a/SIMPLVtkLib/Dialogs/ImportRobometMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportRobometMontageDialog.cpp
@@ -91,7 +91,7 @@ void ImportRobometMontageDialog::setupGui()
 
   connectSignalsSlots();
 
-  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+  setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
   checkComplete();
 }

--- a/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
@@ -100,7 +100,7 @@ void ImportZeissMontageDialog::setupGui()
 
   m_Ui->montageNameLE->setText("Untitled Montage");
 
-  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+  setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
   checkComplete();
 }

--- a/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
@@ -100,6 +100,8 @@ void ImportZeissMontageDialog::setupGui()
 
   m_Ui->montageNameLE->setText("Untitled Montage");
 
+  setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(0));
+
   checkComplete();
 }
 

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -1458,14 +1458,7 @@ void VSFilterViewSettings::updateTransform()
     return;
   }
 
-  if(Representation::Outline == m_Representation)
-  {
-    VSTransform* transform = m_Filter->getTransform();
-    m_Actor->SetPosition(transform->getPosition());
-    m_Actor->SetOrientation(transform->getRotation());
-    m_Actor->SetScale(transform->getScale());
-  }
-  else if(ActorType::Image2D == m_ActorType || ActorType::DataSet == m_ActorType)
+  if(ActorType::Image2D == m_ActorType || ActorType::DataSet == m_ActorType)
   {
 	VTK_PTR(vtkDataSet) outputData = m_Filter->getOutput();
 	vtkImageData* imageData = dynamic_cast<vtkImageData*>(outputData.Get());

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -1330,13 +1330,13 @@ void VSFilterViewSettings::setupDataSetActors()
 
   updateTexture();
 
-  if(!isFlatImage())
-  {
-    mapper->SetInputConnection(m_DataSetFilter->GetOutputPort());
-  }
-  else if(getRepresentation() == Representation::Outline)
+  if(getRepresentation() == Representation::Outline)
   {
     mapper->SetInputConnection(m_OutlineFilter->GetOutputPort());
+  }
+  else if(!isFlatImage())
+  {
+    mapper->SetInputConnection(m_DataSetFilter->GetOutputPort());
   }
   else
   {


### PR DESCRIPTION
Since the combo box defaults to Outline Only, the index changed function is never triggered. To fix it, I set the display type to the 0 index item (which is Outline Only at the moment). 