### PR TITLE
Set selected filters to be temporarily drawn above other filters

### DIFF
--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -552,6 +552,8 @@ void VSFilterViewSettings::setIsSelected(bool selected)
   {
     actor->GetProperty()->EdgeVisibilityOn();
     actor->GetProperty()->SetEdgeColor(0.0, 1.0, 0.0);
+    actor->SetPosition(actor->GetPosition()[0], actor->GetPosition()[1],
+      actor->GetPosition()[2] + 1.0);
   }
   else
   {
@@ -563,6 +565,8 @@ void VSFilterViewSettings::setIsSelected(bool selected)
     {
       actor->GetProperty()->SetEdgeColor(1.0, 1.0, 1.0);
     }
+    actor->SetPosition(actor->GetPosition()[0], actor->GetPosition()[1],
+      actor->GetPosition()[2] - 1.0);
   }
 }
 

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -552,8 +552,7 @@ void VSFilterViewSettings::setIsSelected(bool selected)
   {
     actor->GetProperty()->EdgeVisibilityOn();
     actor->GetProperty()->SetEdgeColor(0.0, 1.0, 0.0);
-    actor->SetPosition(actor->GetPosition()[0], actor->GetPosition()[1],
-      actor->GetPosition()[2] + 1.0);
+    actor->SetPosition(actor->GetPosition()[0], actor->GetPosition()[1], actor->GetPosition()[2] + 1.0);
   }
   else
   {
@@ -565,8 +564,7 @@ void VSFilterViewSettings::setIsSelected(bool selected)
     {
       actor->GetProperty()->SetEdgeColor(1.0, 1.0, 1.0);
     }
-    actor->SetPosition(actor->GetPosition()[0], actor->GetPosition()[1],
-      actor->GetPosition()[2] - 1.0);
+    actor->SetPosition(actor->GetPosition()[0], actor->GetPosition()[1], actor->GetPosition()[2] - 1.0);
   }
 }
 


### PR DESCRIPTION
* Does not change the underlying transform so changes are only visual