### PR TITLE
Hide the Color Mapping widget when incompatible filters are selected

### DIFF
--- a/SIMPLVtkLib/QtWidgets/VSColorMappingWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSColorMappingWidget.cpp
@@ -165,6 +165,16 @@ void VSColorMappingWidget::setFilters(VSAbstractFilter::FilterListType filters)
     break;
   }
 
+  // Check for number of components, if greater than 1
+  // Hide color mapping
+  if(!m_ViewSettings.empty() && m_ViewSettings.front()->getNumberOfComponents(0) > 1)
+  {
+    m_Ui->colorMapLabel->setVisible(false);
+    m_Ui->contentContainer->setVisible(false);
+    m_Ui->colorMappingContainer->setVisible(false);
+  }
+
+
   updateViewSettingInfo();
 }
 


### PR DESCRIPTION
Some image files are loaded as RGB/RGBA data arrays and are not compatible with the functionality of the color mapping widget. This widget seems to only work TIF image files that load as single component unsigned short arrays of scalar data type.