### PR TITLE
Topic/2 d image import fix

### DIFF
--- a/SIMPLVtkLib/QtWidgets/VSMainWidget.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidget.cpp
@@ -327,7 +327,7 @@ void VSMainWidget::importNumFilters(int max)
     m_Internals->progressBar->setMaximum(max);
   }
 
-  m_Internals->progressBar->reset();
+  m_Internals->progressBar->setValue(0);
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/QtWidgets/VSMainWidget2.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSMainWidget2.cpp
@@ -619,7 +619,7 @@ void VSMainWidget2::importNumFilters(int max)
     m_Ui->progressBar->setMaximum(max);
   }
 
-  m_Ui->progressBar->reset();
+  m_Ui->progressBar->setValue(0);
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/SIMPLBridge/SIMPLVtkBridge.cpp
+++ b/SIMPLVtkLib/SIMPLBridge/SIMPLVtkBridge.cpp
@@ -779,14 +779,15 @@ VTK_PTR(vtkDataSet) SIMPLVtkBridge::WrapGeometry(ImageGeom::Pointer image)
 {
   FloatVec3Type res = {0.0f, 0.0f, 0.0f};
   FloatVec3Type origin = {0.0f, 0.0f, 0.0f};
-
-  std::tuple<size_t, size_t, size_t> dims = image->getDimensions();
+  SizeVec3Type dims;
+  image->getDimensions(dims);
+  //std::tuple<size_t, size_t, size_t> dims = image->getDimensions();
   image->getSpacing(res);
   image->getOrigin(origin);
 
   VTK_NEW(vtkImageData, vtkImage);
-  vtkImage->SetExtent(origin[0], origin[0] + std::get<0>(dims), origin[1], origin[1] + std::get<1>(dims), origin[2], origin[2] + std::get<2>(dims));
-  vtkImage->SetDimensions(std::get<0>(dims) + 1, std::get<1>(dims) + 1, std::get<2>(dims) + 1);
+  vtkImage->SetExtent(origin[0], origin[0] + dims[0], origin[1], origin[1] + dims[1], origin[2], origin[2] + dims[2]);
+  vtkImage->SetDimensions(dims[0] + 1, dims[1] + 1, dims[2] + 1);
   vtkImage->SetSpacing(res[0], res[1], res[2]);
   vtkImage->SetOrigin(origin[0], origin[1], origin[2]);
 

--- a/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSConcurrentImport.cpp
@@ -222,7 +222,6 @@ void VSConcurrentImport::partialWrappingThreadFinished()
 
 		filter->getTransform()->setLocalPosition(origin);
 		filter->getTransform()->setOriginPosition(origin);
-        m_Controller->getFilterModel()->addFilter(filter, false);
 
         // SemiReload differs from Reload in that it does not fully load new filters
         if(m_LoadType == LoadType::SemiReload)
@@ -332,6 +331,8 @@ void VSConcurrentImport::applyDataFilters()
     {
       filter->reloadWrappingFinished();
     }
+
+    m_Controller->getFilterModel()->addFilter(filter, false);
 
     // Lock semaphore before the while statement is checked again
     m_UnappliedDataFilterLock.acquire();

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -605,11 +605,11 @@ vtkActor* VSFilterViewSettings::getDataSetActor() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-vtkImageSliceMapper* VSFilterViewSettings::getImageMapper() const
+vtkDataSetMapper* VSFilterViewSettings::getImageMapper() const
 {
   if(ActorType::Image2D == m_ActorType && isValid())
   {
-    return dynamic_cast<vtkImageSliceMapper*>(m_Mapper.Get());
+    return dynamic_cast<vtkDataSetMapper*>(m_Mapper.Get());
   }
 
   return nullptr;
@@ -618,11 +618,11 @@ vtkImageSliceMapper* VSFilterViewSettings::getImageMapper() const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-vtkImageSlice* VSFilterViewSettings::getImageSliceActor() const
+vtkActor* VSFilterViewSettings::getImageActor() const
 {
   if(ActorType::Image2D == m_ActorType && isValid())
   {
-    return dynamic_cast<vtkImageSlice*>(m_Actor.Get());
+    return dynamic_cast<vtkActor*>(m_Actor.Get());
   }
 
   return nullptr;
@@ -1035,13 +1035,13 @@ void VSFilterViewSettings::updateDataSetAlpha()
 // -----------------------------------------------------------------------------
 void VSFilterViewSettings::updateImageAlpha()
 {
-  vtkImageSlice* actor = getImageSliceActor();
+  vtkActor* actor = getImageActor();
   if(nullptr == actor)
   {
     return;
   }
 
-  vtkImageProperty* property = actor->GetProperty();
+  vtkProperty* property = actor->GetProperty();
   property->SetOpacity(m_Alpha);
   actor->SetProperty(property);
 }

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -1152,23 +1152,18 @@ void VSFilterViewSettings::setupActors(bool outline)
     return;
   }
 
-  if(isFlatImage() && hasSinglePointArray())
+  if(isFlatImage())
   {
     setupImageActors();
+    setScalarBarSetting(ScalarBarSetting::Never);
   }
   else
   {
     setupDataSetActors();
 
-    if(isFlatImage())
-    {
-      setScalarBarSetting(ScalarBarSetting::Never);
-    }
-    else
-    {
-      // Refresh ScalarBarSetting
-      setScalarBarSetting(m_ScalarBarSetting);
-    }
+    // Refresh ScalarBarSetting
+    setScalarBarSetting(m_ScalarBarSetting);
+
   }
 
   setupCubeAxesActor();
@@ -1210,13 +1205,6 @@ bool VSFilterViewSettings::isFlatImage()
     {
       return true;
     }
-  }
-
-  // Check bounds of image data
-  double* bounds = imageData->GetBounds();
-  if(bounds[4] == 0 && (bounds[5] == 0 || bounds[5] == 1))
-  {
-    return true;
   }
 
   return false;

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.cpp
@@ -1266,6 +1266,24 @@ void VSFilterViewSettings::setupImageActors()
   m_Actor = actor;
   m_Plane = plane;
 
+  vtkImageData* imageData = dynamic_cast<vtkImageData*>(outputData.Get());
+
+  double spacing[3];
+  imageData->GetSpacing(spacing);
+
+  // Get transform vectors
+  VSTransform* transform = m_Filter->getTransform();
+
+  double scaling[3] = {spacing[0], spacing[1], spacing[2]};
+
+  transform->setLocalScale(scaling);
+
+  // Save the initial transform
+  VSTransform* defaultTransform = getDefaultTransform();
+  defaultTransform->setLocalPosition(m_Filter->getTransform()->getLocalPosition());
+  defaultTransform->setLocalRotation(m_Filter->getTransform()->getLocalRotation());
+  defaultTransform->setLocalScale(m_Filter->getTransform()->getLocalScale());
+
   m_ActorType = ActorType::Image2D;
   updateTexture();
   updateTransform();
@@ -1324,13 +1342,9 @@ void VSFilterViewSettings::setupDataSetActors()
   {
     mapper->SetInputConnection(m_OutlineFilter->GetOutputPort());
   }
-  else if(!isFlatImage())
-  {
-    mapper->SetInputConnection(m_DataSetFilter->GetOutputPort());
-  }
   else
   {
-    mapper->SetInputConnection(plane->GetOutputPort());
+    mapper->SetInputConnection(m_DataSetFilter->GetOutputPort());
   }
   actor->SetMapper(mapper);
 
@@ -1377,26 +1391,7 @@ void VSFilterViewSettings::setupDataSetActors()
   m_Plane = plane;
 
   m_ActorType = ActorType::DataSet;
-  if(isFlatImage())
-  {
-    vtkImageData* imageData = dynamic_cast<vtkImageData*>(outputData.Get());
 
-    double spacing[3];
-    imageData->GetSpacing(spacing);
-
-    // Get transform vectors
-    VSTransform* transform = m_Filter->getTransform();
-
-    double scaling[3] = {spacing[0], spacing[1], spacing[2]};
-
-    transform->setLocalScale(scaling);
-
-    // Save the initial transform
-    VSTransform* defaultTransform = getDefaultTransform();
-    defaultTransform->setLocalPosition(m_Filter->getTransform()->getLocalPosition());
-    defaultTransform->setLocalRotation(m_Filter->getTransform()->getLocalRotation());
-    defaultTransform->setLocalScale(m_Filter->getTransform()->getLocalScale());
-  }
   updateTransform();
 }
 

--- a/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
+++ b/SIMPLVtkLib/Visualization/Controllers/VSFilterViewSettings.h
@@ -885,18 +885,18 @@ protected:
   vtkActor* getDataSetActor() const;
 
   /**
-   * @brief Returns the vtkImageSliceMapper if the ActorType is Image2D and the settings are valid.
+   * @brief Returns the vtkDataSetMapper if the ActorType is Image2D and the settings are valid.
    * Returns nullptr otherwise.
    * @return
    */
-  vtkImageSliceMapper* getImageMapper() const;
+  vtkDataSetMapper* getImageMapper() const;
 
   /**
-   * @brief Returns the vtkImageSlice if the ActorType is Image2D and the settings are valid.
+   * @brief Returns the vtkActor if the ActorType is Image2D and the settings are valid.
    * Returns nullptr otherwise.
    * @return
    */
-  vtkImageSlice* getImageSliceActor() const;
+  vtkActor* getImageActor() const;
 
   /**
    * @brief Returns true if data set is a 2D image.  Returns false otherwise.

--- a/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.cpp
+++ b/SIMPLVtkLib/Visualization/VisualFilters/VSSIMPLDataContainerFilter.cpp
@@ -499,17 +499,6 @@ double* VSSIMPLDataContainerFilter::getTransformBounds()
   VTK_PTR(vtkDataSet) outputData = getOutput();
   VTK_PTR(vtkImageData) imageData = dynamic_cast<vtkImageData*>(outputData.Get());
 
-  double* bounds = imageData->GetBounds();
-  if(!(bounds[4] == 0 && (bounds[5] == 0 || bounds[5] == 1)))
-  {
-    VTK_PTR(vtkTransformFilter) trans = VTK_PTR(vtkTransformFilter)::New();
-    trans->SetInputConnection(getOutputPort());
-    trans->SetTransform(getTransform()->getGlobalTransform());
-    trans->ReleaseDataFlagOn();
-    trans->Update();
-    return trans->GetOutput()->GetBounds();
-  }
-
   // Subsample the image to reduce amount of data stored in transform filter
   VTK_PTR(vtkExtractVOI) subsample = VTK_PTR(vtkExtractVOI)::New();
   int* inputDims = imageData->GetDimensions();


### PR DESCRIPTION
Fixing issues that were resulting in texturing errors when trying to read 2D images.

Data is now determined to be a flat image when the vtkImageData object has at least one dimension equal to 1.  This means that the image data coming in from DREAM3D has to have at least one dimension equal to 0 since we add 1 to every dimension.