### PR TITLE
Fixed an issue where undo and redo transform caused out of range error

### DIFF
--- a/SIMPLVtkLib/QtWidgets/VSInteractorStyleFilterCamera.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSInteractorStyleFilterCamera.cpp
@@ -1115,6 +1115,10 @@ void VSInteractorStyleFilterCamera::resetTransform()
 // -----------------------------------------------------------------------------
 void VSInteractorStyleFilterCamera::undoTransform()
 {
+  if(m_PreviousTransforms.empty())
+  {
+    return;
+  }
   VSAbstractFilter::FilterListType selection = getFilterSelection();
 
   for(VSAbstractFilter* filter : selection)
@@ -1140,6 +1144,10 @@ void VSInteractorStyleFilterCamera::undoTransform()
 // -----------------------------------------------------------------------------
 void VSInteractorStyleFilterCamera::redoTransform()
 {
+  if(m_LastUndoneTransforms.empty())
+  {
+    return;
+  }
   VSAbstractFilter::FilterListType selection = getFilterSelection();
 
   for(VSAbstractFilter* filter : selection)


### PR DESCRIPTION
Attempting to undo transforms when first loading an image dataset, causes an out of range error to occur. This pull request fixes that by checking if there were any previous transforms before going further into the function.