### PR TITLE
Montage Start and End

### DIFF
--- a/SIMPLVtkLib/Common/MontageUtilities.cpp
+++ b/SIMPLVtkLib/Common/MontageUtilities.cpp
@@ -45,6 +45,29 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
+QString MontageUtilities::FindDataContainerPrefix(const QStringList& dcNames)
+{
+  if(dcNames.empty())
+  {
+    return {};
+  }
+
+  for(const QString& dcName : dcNames)
+  {
+    if(!dcName.contains(QRegExp("r\\d+c\\d+")))
+    {
+      return {};
+    }
+  }
+
+  QString dcPrefix = dcNames[0];
+  dcPrefix.remove(QRegExp("r\\d+c\\d+"));
+  return dcPrefix;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
 QString MontageUtilities::GenerateDataContainerName(const QString& dataContainerPrefix, const IntVec2Type& montageStart, const IntVec2Type& montageEnd, int32_t row, int32_t col)
 {
   IntVec3Type montageSize;

--- a/SIMPLVtkLib/Common/MontageUtilities.cpp
+++ b/SIMPLVtkLib/Common/MontageUtilities.cpp
@@ -35,9 +35,9 @@
 
 #include "MontageUtilities.h"
 
+#include <QtCore/QFileInfo>
 #include <QtCore/QString>
 #include <QtCore/QTextStream>
-#include <QtCore/QFileInfo>
 
 #include "SIMPLib/DataContainers/DataContainer.h"
 #include "SIMPLib/Utilities/SIMPLH5DataReaderRequirements.h"
@@ -45,7 +45,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QString MontageUtilities::GenerateDataContainerName(const QString& dataContainerPrefix, const IntVec3Type& montageStart, const IntVec3Type& montageEnd, int32_t row, int32_t col)
+QString MontageUtilities::GenerateDataContainerName(const QString& dataContainerPrefix, const IntVec2Type& montageStart, const IntVec2Type& montageEnd, int32_t row, int32_t col)
 {
   IntVec3Type montageSize;
   std::transform(montageStart.begin(), montageStart.end(), montageEnd.begin(), montageSize.begin(), [](int32_t a, int32_t b) -> int32_t { return a + b + 1; });
@@ -73,7 +73,7 @@ QString MontageUtilities::GenerateDataContainerName(const QString& dataContainer
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-DataContainerArrayProxy MontageUtilities::CreateMontageProxy(SIMPLH5DataReader &reader, const QString& filePath, const QStringList &checkedDCNames)
+DataContainerArrayProxy MontageUtilities::CreateMontageProxy(SIMPLH5DataReader& reader, const QString& filePath, const QStringList& checkedDCNames)
 {
   bool success = reader.openFile(filePath);
   if(!success)

--- a/SIMPLVtkLib/Common/MontageUtilities.h
+++ b/SIMPLVtkLib/Common/MontageUtilities.h
@@ -47,6 +47,12 @@ class SIMPLVtkLib_EXPORT MontageUtilities
 {
 public:
   /**
+   * @brief FindDataContainerPrefix
+   * @param dcNames
+   */
+  static QString FindDataContainerPrefix(const QStringList& dcNames);
+
+  /**
    * @brief GenerateDataContainerName
    * @param dataContainerPrefix
    * @param montageStart

--- a/SIMPLVtkLib/Common/MontageUtilities.h
+++ b/SIMPLVtkLib/Common/MontageUtilities.h
@@ -55,7 +55,7 @@ public:
    * @param col
    * @return
    */
-  static QString GenerateDataContainerName(const QString& dataContainerPrefix, const IntVec3Type& montageStart, const IntVec3Type& montageEnd, int32_t row, int32_t col);
+  static QString GenerateDataContainerName(const QString& dataContainerPrefix, const IntVec2Type& montageStart, const IntVec2Type& montageEnd, int32_t row, int32_t col);
 
   /**
    * @brief CreateMontageProxy
@@ -64,10 +64,9 @@ public:
    * @param checkedDCNames
    * @return
    */
-  static DataContainerArrayProxy CreateMontageProxy(SIMPLH5DataReader &reader, const QString &filePath, const QStringList &checkedDCNames = QStringList());
+  static DataContainerArrayProxy CreateMontageProxy(SIMPLH5DataReader& reader, const QString& filePath, const QStringList& checkedDCNames = QStringList());
 
 private:
-
   /**
    * @brief CalculatePaddingDigits
    * @param count

--- a/SIMPLVtkLib/Dialogs/FijiListWidget.cpp
+++ b/SIMPLVtkLib/Dialogs/FijiListWidget.cpp
@@ -459,3 +459,11 @@ QString FijiListWidget::getInputDirectory()
   }
   return m_Ui->inputDir->text();
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+int FijiListWidget::getCurrentNumberOfTiles()
+{
+  return m_Ui->fileListView->count();
+}

--- a/SIMPLVtkLib/Dialogs/FijiListWidget.h
+++ b/SIMPLVtkLib/Dialogs/FijiListWidget.h
@@ -118,6 +118,12 @@ public:
    */
   FijiListInfo_t getFijiListInfo();
 
+  /**
+   * @brief getCurrentNumberOfTiles
+   * @return
+   */
+  int getCurrentNumberOfTiles();
+
 protected slots:
 
   // Slots to catch signals emitted by the various ui widgets

--- a/SIMPLVtkLib/Dialogs/FijiListWidget.h
+++ b/SIMPLVtkLib/Dialogs/FijiListWidget.h
@@ -177,18 +177,6 @@ signals:
    */
   void inputDirectoryChanged(const QString& dirPath);
 
-  /**
-   * @brief numberOfRowsChanged
-   * @param numberOfRows
-   */
-  void numberOfRowsChanged(size_t numberOfRows);
-
-  /**
-   * @brief numberOfColumnsChanged
-   * @param numOfCols
-   */
-  void numberOfColumnsChanged(size_t numOfCols);
-
 private:
   QSharedPointer<Ui::FijiListWidget> m_Ui;
 

--- a/SIMPLVtkLib/Dialogs/ImportDREAM3DMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportDREAM3DMontageDialog.cpp
@@ -266,7 +266,7 @@ void ImportDREAM3DMontageDialog::dataFile_textChanged(const QString& text)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void ImportDREAM3DMontageDialog::setInputDirectory(const QString &val)
+void ImportDREAM3DMontageDialog::setInputDirectory(const QString& val)
 {
   m_Ui->dataFileLE->setText(val);
 }
@@ -302,18 +302,18 @@ QString ImportDREAM3DMontageDialog::getMontageName()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportDREAM3DMontageDialog::getMontageStart()
+IntVec2Type ImportDREAM3DMontageDialog::getMontageStart()
 {
-  IntVec3Type montageStart = {m_Ui->montageStartX->text().toInt(), m_Ui->montageStartY->text().toInt(), 1};
+  IntVec2Type montageStart = {m_Ui->montageStartX->text().toInt(), m_Ui->montageStartY->text().toInt()};
   return montageStart;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportDREAM3DMontageDialog::getMontageEnd()
+IntVec2Type ImportDREAM3DMontageDialog::getMontageEnd()
 {
-  IntVec3Type montageEnd = {m_Ui->montageEndX->text().toInt(), m_Ui->montageEndY->text().toInt(), 1};
+  IntVec2Type montageEnd = {m_Ui->montageEndX->text().toInt(), m_Ui->montageEndY->text().toInt()};
   return montageEnd;
 }
 

--- a/SIMPLVtkLib/Dialogs/ImportDREAM3DMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportDREAM3DMontageDialog.h
@@ -81,13 +81,13 @@ public:
    * @brief getMontageStart
    * @return
    */
-  IntVec3Type getMontageStart();
+  IntVec2Type getMontageStart();
 
   /**
    * @brief getMontageEnd
    * @return
    */
-  IntVec3Type getMontageEnd();
+  IntVec2Type getMontageEnd();
 
   /**
    * @brief getMontageSize
@@ -140,10 +140,10 @@ protected slots:
   void dataFile_textChanged(const QString& text);
 
 protected:
-  void setInputDirectory(const QString &val);
+  void setInputDirectory(const QString& val);
   QString getInputDirectory();
 
-  static void setOpenDialogLastFilePath(const QString &val)
+  static void setOpenDialogLastFilePath(const QString& val)
   {
     m_OpenDialogLastDirectory = val;
   }

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
@@ -99,6 +99,11 @@ void ImportFijiMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
+  m_Ui->montageStartX->setValidator(new QDoubleValidator);
+  m_Ui->montageStartY->setValidator(new QDoubleValidator);
+  m_Ui->montageEndX->setValidator(new QDoubleValidator);
+  m_Ui->montageEndY->setValidator(new QDoubleValidator);
+
   setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
   checkComplete();
@@ -112,8 +117,6 @@ void ImportFijiMontageDialog::connectSignalsSlots()
   connect(m_Ui->dataDisplayTypeCB, qOverload<int>(&QComboBox::currentIndexChanged), [=](int index) { setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(index)); });
 
   connect(m_Ui->fijiListWidget, &FijiListWidget::inputDirectoryChanged, this, &ImportFijiMontageDialog::fijiListWidgetChanged);
-  connect(m_Ui->fijiListWidget, &FijiListWidget::numberOfRowsChanged, this, &ImportFijiMontageDialog::fijiListWidgetChanged);
-  connect(m_Ui->fijiListWidget, &FijiListWidget::numberOfColumnsChanged, this, &ImportFijiMontageDialog::fijiListWidgetChanged);
 
   connect(m_Ui->changeOriginCB, &QCheckBox::stateChanged, this, &ImportFijiMontageDialog::changeOrigin_stateChanged);
   connect(m_Ui->originX, &QLineEdit::textChanged, [=] { checkComplete(); });
@@ -124,6 +127,11 @@ void ImportFijiMontageDialog::connectSignalsSlots()
   connect(m_Ui->spacingX, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->spacingY, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->spacingZ, &QLineEdit::textChanged, [=] { checkComplete(); });
+
+  connect(m_Ui->montageStartX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageStartY, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndY, &QLineEdit::textChanged, [=] { checkComplete(); });
 }
 
 // -----------------------------------------------------------------------------
@@ -253,6 +261,38 @@ void ImportFijiMontageDialog::checkComplete() const
     }
   }
 
+  if(m_Ui->montageStartX->isEnabled())
+  {
+    if(m_Ui->montageStartX->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageStartY->isEnabled())
+  {
+    if(m_Ui->montageStartY->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageEndX->isEnabled())
+  {
+    if(m_Ui->montageEndX->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageEndY->isEnabled())
+  {
+    if(m_Ui->montageEndY->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
   QPushButton* okBtn = m_Ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
   if(!okBtn)
   {
@@ -308,6 +348,28 @@ FloatVec3Type ImportFijiMontageDialog::getOrigin()
   float originZ = m_Ui->originZ->text().toFloat();
   FloatVec3Type origin = {originX, originY, originZ};
   return origin;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportFijiMontageDialog::getMontageStart()
+{
+  int montageStartX = m_Ui->montageStartX->text().toInt();
+  int montageStartY = m_Ui->montageStartY->text().toInt();
+  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  return montageStart;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportFijiMontageDialog::getMontageEnd()
+{
+  int montageEndX = m_Ui->montageStartX->text().toInt();
+  int montageEndY = m_Ui->montageStartY->text().toInt();
+  IntVec3Type montageEnd = {montageEndX, montageEndY, 1};
+  return montageEnd;
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
@@ -92,6 +92,9 @@ void ImportFijiMontageDialog::setupGui()
 
   connectSignalsSlots();
 
+  SVStyle* style = SVStyle::Instance();
+  m_Ui->errLabel->setStyleSheet(tr("QLabel { color: %1; }").arg(style->getWidget_Error_color().name()));
+
   m_Ui->originX->setValidator(new QDoubleValidator);
   m_Ui->originY->setValidator(new QDoubleValidator);
   m_Ui->originZ->setValidator(new QDoubleValidator);
@@ -199,6 +202,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->montageNameLE->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Montage name is empty");
       result = false;
     }
   }
@@ -207,6 +211,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(!m_Ui->fijiListWidget->isComplete())
     {
+      m_Ui->errLabel->setText("Fiji file list is incomplete.");
       result = false;
     }
   }
@@ -215,6 +220,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->originX->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Origin X is empty");
       result = false;
     }
   }
@@ -223,6 +229,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->originY->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Origin Y is empty");
       result = false;
     }
   }
@@ -231,6 +238,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->originZ->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Origin Z is empty");
       result = false;
     }
   }
@@ -239,6 +247,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->spacingX->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Spacing X is empty");
       result = false;
     }
   }
@@ -247,6 +256,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->spacingY->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Spacing Y is empty");
       result = false;
     }
   }
@@ -255,6 +265,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->spacingZ->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Spacing Z is empty");
       result = false;
     }
   }
@@ -263,6 +274,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->montageStartX->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Montage Start X is empty");
       result = false;
     }
   }
@@ -271,6 +283,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->montageStartY->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Montage Start Y is empty");
       result = false;
     }
   }
@@ -279,6 +292,7 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->montageEndX->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Montage End X is empty");
       result = false;
     }
   }
@@ -287,9 +301,30 @@ void ImportFijiMontageDialog::checkComplete() const
   {
     if(m_Ui->montageEndY->text().isEmpty())
     {
+      m_Ui->errLabel->setText("Montage End Y is empty");
       result = false;
     }
   }
+  
+  // Check that size of montage based on start and end is valid
+  int montageStartX = m_Ui->montageStartX->text().toInt();
+  int montageStartY = m_Ui->montageStartY->text().toInt();
+  int montageEndX = m_Ui->montageEndX->text().toInt();
+  int montageEndY = m_Ui->montageEndY->text().toInt();
+  int numCols = montageEndX - montageStartX + 1;
+  int numRows = montageEndY - montageStartY + 1;
+
+  int numberOfMontageTiles = numCols * numRows;
+  int numberOfSelectedTiles = m_Ui->fijiListWidget->getCurrentNumberOfTiles();
+  if(numberOfSelectedTiles < numberOfMontageTiles)
+  {
+    m_Ui->errLabel->setText(tr("The number of tiles in the tile list (%1) is less than the number of tiles declared in the montage (%2).\nPlease update"
+                               " the tile list as well as the 'Montage Start' and 'Montage End' fields.")
+                                .arg(numberOfSelectedTiles)
+                                .arg(numberOfMontageTiles));
+    result = false;
+  }
+
 
   QPushButton* okBtn = m_Ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
   if(okBtn == nullptr)
@@ -298,6 +333,7 @@ void ImportFijiMontageDialog::checkComplete() const
   }
 
   okBtn->setEnabled(result);
+  m_Ui->errLabel->setVisible(!result);
 }
 
 // -----------------------------------------------------------------------------
@@ -364,8 +400,8 @@ IntVec3Type ImportFijiMontageDialog::getMontageStart()
 // -----------------------------------------------------------------------------
 IntVec3Type ImportFijiMontageDialog::getMontageEnd()
 {
-  int montageEndX = m_Ui->montageStartX->text().toInt();
-  int montageEndY = m_Ui->montageStartY->text().toInt();
+  int montageEndX = m_Ui->montageEndX->text().toInt();
+  int montageEndY = m_Ui->montageEndY->text().toInt();
   IntVec3Type montageEnd = {montageEndX, montageEndY, 1};
   return montageEnd;
 }

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
@@ -99,6 +99,11 @@ void ImportFijiMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
+  m_Ui->montageStartX->setValidator(new QDoubleValidator);
+  m_Ui->montageStartY->setValidator(new QDoubleValidator);
+  m_Ui->montageEndX->setValidator(new QDoubleValidator);
+  m_Ui->montageEndY->setValidator(new QDoubleValidator);
+
   setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
   checkComplete();
@@ -112,8 +117,6 @@ void ImportFijiMontageDialog::connectSignalsSlots()
   connect(m_Ui->dataDisplayTypeCB, qOverload<int>(&QComboBox::currentIndexChanged), [=](int index) { setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(index)); });
 
   connect(m_Ui->fijiListWidget, &FijiListWidget::inputDirectoryChanged, this, &ImportFijiMontageDialog::fijiListWidgetChanged);
-  connect(m_Ui->fijiListWidget, &FijiListWidget::numberOfRowsChanged, this, &ImportFijiMontageDialog::fijiListWidgetChanged);
-  connect(m_Ui->fijiListWidget, &FijiListWidget::numberOfColumnsChanged, this, &ImportFijiMontageDialog::fijiListWidgetChanged);
 
   connect(m_Ui->changeOriginCB, &QCheckBox::stateChanged, this, &ImportFijiMontageDialog::changeOrigin_stateChanged);
   connect(m_Ui->originX, &QLineEdit::textChanged, [=] { checkComplete(); });
@@ -124,6 +127,11 @@ void ImportFijiMontageDialog::connectSignalsSlots()
   connect(m_Ui->spacingX, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->spacingY, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->spacingZ, &QLineEdit::textChanged, [=] { checkComplete(); });
+
+  connect(m_Ui->montageStartX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageStartY, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndY, &QLineEdit::textChanged, [=] { checkComplete(); });
 }
 
 // -----------------------------------------------------------------------------
@@ -251,6 +259,38 @@ void ImportFijiMontageDialog::checkComplete() const
     }
   }
 
+  if(m_Ui->montageStartX->isEnabled())
+  {
+    if(m_Ui->montageStartX->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageStartY->isEnabled())
+  {
+    if(m_Ui->montageStartY->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageEndX->isEnabled())
+  {
+    if(m_Ui->montageEndX->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageEndY->isEnabled())
+  {
+    if(m_Ui->montageEndY->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
   QPushButton* okBtn = m_Ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
   if(okBtn == nullptr)
   {
@@ -306,6 +346,28 @@ FloatVec3Type ImportFijiMontageDialog::getOrigin()
   float originZ = m_Ui->originZ->text().toFloat();
   FloatVec3Type origin = {originX, originY, originZ};
   return origin;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportFijiMontageDialog::getMontageStart()
+{
+  int montageStartX = m_Ui->montageStartX->text().toInt();
+  int montageStartY = m_Ui->montageStartY->text().toInt();
+  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  return montageStart;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportFijiMontageDialog::getMontageEnd()
+{
+  int montageEndX = m_Ui->montageStartX->text().toInt();
+  int montageEndY = m_Ui->montageStartY->text().toInt();
+  IntVec3Type montageEnd = {montageEndX, montageEndY, 1};
+  return montageEnd;
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
@@ -325,7 +325,6 @@ void ImportFijiMontageDialog::checkComplete() const
     result = false;
   }
 
-
   QPushButton* okBtn = m_Ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
   if(okBtn == nullptr)
   {

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.cpp
@@ -305,7 +305,7 @@ void ImportFijiMontageDialog::checkComplete() const
       result = false;
     }
   }
-  
+
   // Check that size of montage based on start and end is valid
   int montageStartX = m_Ui->montageStartX->text().toInt();
   int montageStartY = m_Ui->montageStartY->text().toInt();
@@ -386,22 +386,22 @@ FloatVec3Type ImportFijiMontageDialog::getOrigin()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportFijiMontageDialog::getMontageStart()
+IntVec2Type ImportFijiMontageDialog::getMontageStart()
 {
   int montageStartX = m_Ui->montageStartX->text().toInt();
   int montageStartY = m_Ui->montageStartY->text().toInt();
-  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  IntVec2Type montageStart = {montageStartX, montageStartY};
   return montageStart;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportFijiMontageDialog::getMontageEnd()
+IntVec2Type ImportFijiMontageDialog::getMontageEnd()
 {
   int montageEndX = m_Ui->montageEndX->text().toInt();
   int montageEndY = m_Ui->montageEndY->text().toInt();
-  IntVec3Type montageEnd = {montageEndX, montageEndY, 1};
+  IntVec2Type montageEnd = {montageEndX, montageEndY};
   return montageEnd;
 }
 

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.h
@@ -107,13 +107,13 @@ public:
    * @brief getMontageStart
    * @return
    */
-  IntVec3Type getMontageStart();
+  IntVec2Type getMontageStart();
 
   /**
    * @brief getMontageEnd
    * @return
    */
-  IntVec3Type getMontageEnd();
+  IntVec2Type getMontageEnd();
 
   /**
    * @brief getLengthUnit
@@ -138,7 +138,7 @@ protected slots:
   void fijiListWidgetChanged();
 
 protected:
-  static void setOpenDialogLastFilePath(const QString &val)
+  static void setOpenDialogLastFilePath(const QString& val)
   {
     m_OpenDialogLastDirectory = val;
   }

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.h
@@ -104,6 +104,18 @@ public:
   FloatVec3Type getOrigin();
 
   /**
+   * @brief getMontageStart
+   * @return
+   */
+  IntVec3Type getMontageStart();
+
+  /**
+   * @brief getMontageEnd
+   * @return
+   */
+  IntVec3Type getMontageEnd();
+
+  /**
    * @brief getLengthUnit
    * @return
    */

--- a/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportFijiMontageDialog.h
@@ -104,6 +104,18 @@ public:
   FloatVec3Type getOrigin();
 
   /**
+   * @brief getMontageStart
+   * @return
+   */
+  IntVec3Type getMontageStart();
+
+  /**
+   * @brief getMontageEnd
+   * @return
+   */
+  IntVec3Type getMontageEnd();
+
+  /**
    * @brief usePixelCoordinates
    * @return
    */

--- a/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
@@ -341,22 +341,22 @@ QString ImportGenericMontageDialog::getMontageName()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportGenericMontageDialog::getMontageStart()
+IntVec2Type ImportGenericMontageDialog::getMontageStart()
 {
   int montageStartX = m_Ui->montageStartX->text().toInt();
   int montageStartY = m_Ui->montageStartY->text().toInt();
-  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  IntVec2Type montageStart = {montageStartX, montageStartY};
   return montageStart;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportGenericMontageDialog::getMontageEnd()
+IntVec2Type ImportGenericMontageDialog::getMontageEnd()
 {
   int montageEndX = m_Ui->montageEndX->text().toInt();
   int montageEndY = m_Ui->montageEndY->text().toInt();
-  IntVec3Type montageStart = {montageEndX, montageEndY, 1};
+  IntVec2Type montageStart = {montageEndX, montageEndY};
   return montageStart;
 }
 

--- a/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
@@ -88,12 +88,6 @@ void ImportGenericMontageDialog::setupGui()
   SVStyle* style = SVStyle::Instance();
   m_Ui->errLabel->setStyleSheet(tr("QLabel { color: %1; }").arg(style->getWidget_Error_color().name()));
 
-  m_Ui->numOfRowsSB->setMinimum(1);
-  m_Ui->numOfRowsSB->setMaximum(std::numeric_limits<int>::max());
-
-  m_Ui->numOfColsSB->setMinimum(1);
-  m_Ui->numOfColsSB->setMaximum(std::numeric_limits<int>::max());
-
   m_Ui->tileOverlapSB->setMinimum(0);
   m_Ui->tileOverlapSB->setMaximum(100);
 
@@ -103,6 +97,10 @@ void ImportGenericMontageDialog::setupGui()
   m_Ui->spacingX->setValidator(new QDoubleValidator);
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
+  m_Ui->montageStartX->setValidator(new QDoubleValidator);
+  m_Ui->montageStartY->setValidator(new QDoubleValidator);
+  m_Ui->montageEndX->setValidator(new QDoubleValidator);
+  m_Ui->montageEndY->setValidator(new QDoubleValidator);
 
   setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
@@ -116,8 +114,6 @@ void ImportGenericMontageDialog::connectSignalsSlots()
 {
   connect(m_Ui->dataDisplayTypeCB, qOverload<int>(&QComboBox::currentIndexChanged), [=](int index) { setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(index)); });
 
-  connect(m_Ui->numOfRowsSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=] { checkComplete(); });
-  connect(m_Ui->numOfColsSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=] { checkComplete(); });
   connect(m_Ui->tileOverlapSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=] { checkComplete(); });
 
   connect(m_Ui->montageNameLE, &QLineEdit::textChanged, this, [=] { checkComplete(); });
@@ -139,6 +135,11 @@ void ImportGenericMontageDialog::connectSignalsSlots()
   connect(m_Ui->originX, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->originY, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->originZ, &QLineEdit::textChanged, [=] { checkComplete(); });
+
+  connect(m_Ui->montageStartX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageStartY, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndY, &QLineEdit::textChanged, [=] { checkComplete(); });
 
   connect(m_Ui->changeSpacingCB, &QCheckBox::stateChanged, [=] {
     bool isChecked = m_Ui->changeSpacingCB->isChecked();
@@ -202,7 +203,14 @@ void ImportGenericMontageDialog::checkComplete() const
     result = false;
   }
 
-  int numberOfMontageTiles = m_Ui->numOfRowsSB->value() * m_Ui->numOfColsSB->value();
+  int montageStartX = m_Ui->montageStartX->text().toInt();
+  int montageStartY = m_Ui->montageStartY->text().toInt();
+  int montageEndX = m_Ui->montageEndX->text().toInt();
+  int montageEndY = m_Ui->montageEndY->text().toInt();
+  int numCols = montageEndX - montageStartX + 1;
+  int numRows = montageEndY - montageStartY + 1;
+
+  int numberOfMontageTiles = numCols * numRows;
   int numberOfSelectedTiles = m_Ui->tileListWidget->getCurrentNumberOfTiles();
   if(numberOfSelectedTiles != numberOfMontageTiles)
   {
@@ -333,10 +341,23 @@ QString ImportGenericMontageDialog::getMontageName()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-std::tuple<int, int> ImportGenericMontageDialog::getMontageDimensions()
+IntVec3Type ImportGenericMontageDialog::getMontageStart()
 {
-  std::tuple<int, int> dims = std::make_tuple(m_Ui->numOfRowsSB->value(), m_Ui->numOfColsSB->value());
-  return dims;
+  int montageStartX = m_Ui->montageStartX->text().toInt();
+  int montageStartY = m_Ui->montageStartY->text().toInt();
+  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  return montageStart;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportGenericMontageDialog::getMontageEnd()
+{
+  int montageEndX = m_Ui->montageEndX->text().toInt();
+  int montageEndY = m_Ui->montageEndY->text().toInt();
+  IntVec3Type montageStart = {montageEndX, montageEndY, 1};
+  return montageStart;
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
@@ -212,10 +212,10 @@ void ImportGenericMontageDialog::checkComplete() const
 
   int numberOfMontageTiles = numCols * numRows;
   int numberOfSelectedTiles = m_Ui->tileListWidget->getCurrentNumberOfTiles();
-  if(numberOfSelectedTiles != numberOfMontageTiles)
+  if(numberOfSelectedTiles < numberOfMontageTiles)
   {
-    m_Ui->errLabel->setText(tr("The number of tiles in the tile list (%1) does not match the number of tiles declared in the montage (%2).\nPlease update"
-                               " the tile list as well as the 'Total Rows' and 'Total Columns' fields.")
+    m_Ui->errLabel->setText(tr("The number of tiles in the tile list (%1) is less than the number of tiles declared in the montage (%2).\nPlease update"
+                               " the tile list as well as the 'Montage Start' and 'Montage End' fields.")
                                 .arg(numberOfSelectedTiles)
                                 .arg(numberOfMontageTiles));
     result = false;

--- a/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.cpp
@@ -88,12 +88,6 @@ void ImportGenericMontageDialog::setupGui()
   SVStyle* style = SVStyle::Instance();
   m_Ui->errLabel->setStyleSheet(tr("QLabel { color: %1; }").arg(style->getWidget_Error_color().name()));
 
-  m_Ui->numOfRowsSB->setMinimum(1);
-  m_Ui->numOfRowsSB->setMaximum(std::numeric_limits<int>().max());
-
-  m_Ui->numOfColsSB->setMinimum(1);
-  m_Ui->numOfColsSB->setMaximum(std::numeric_limits<int>().max());
-
   m_Ui->tileOverlapSB->setMinimum(0);
   m_Ui->tileOverlapSB->setMaximum(100);
 
@@ -103,6 +97,10 @@ void ImportGenericMontageDialog::setupGui()
   m_Ui->spacingX->setValidator(new QDoubleValidator);
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
+  m_Ui->montageStartX->setValidator(new QDoubleValidator);
+  m_Ui->montageStartY->setValidator(new QDoubleValidator);
+  m_Ui->montageEndX->setValidator(new QDoubleValidator);
+  m_Ui->montageEndY->setValidator(new QDoubleValidator);
 
   setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
 
@@ -116,8 +114,6 @@ void ImportGenericMontageDialog::connectSignalsSlots()
 {
   connect(m_Ui->dataDisplayTypeCB, qOverload<int>(&QComboBox::currentIndexChanged), [=](int index) { setDisplayType(static_cast<AbstractImportMontageDialog::DisplayType>(index)); });
 
-  connect(m_Ui->numOfRowsSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=] { checkComplete(); });
-  connect(m_Ui->numOfColsSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=] { checkComplete(); });
   connect(m_Ui->tileOverlapSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=] { checkComplete(); });
 
   connect(m_Ui->montageNameLE, &QLineEdit::textChanged, this, [=] { checkComplete(); });
@@ -139,6 +135,11 @@ void ImportGenericMontageDialog::connectSignalsSlots()
   connect(m_Ui->originX, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->originY, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->originZ, &QLineEdit::textChanged, [=] { checkComplete(); });
+
+  connect(m_Ui->montageStartX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageStartY, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndY, &QLineEdit::textChanged, [=] { checkComplete(); });
 
   connect(m_Ui->changeSpacingCB, &QCheckBox::stateChanged, [=] {
     bool isChecked = m_Ui->changeSpacingCB->isChecked();
@@ -202,7 +203,14 @@ void ImportGenericMontageDialog::checkComplete() const
     result = false;
   }
 
-  int numberOfMontageTiles = m_Ui->numOfRowsSB->value() * m_Ui->numOfColsSB->value();
+  int montageStartX = m_Ui->montageStartX->text().toInt();
+  int montageStartY = m_Ui->montageStartY->text().toInt();
+  int montageEndX = m_Ui->montageEndX->text().toInt();
+  int montageEndY = m_Ui->montageEndY->text().toInt();
+  int numCols = montageEndX - montageStartX + 1;
+  int numRows = montageEndY - montageStartY + 1;
+
+  int numberOfMontageTiles = numCols * numRows;
   int numberOfSelectedTiles = m_Ui->tileListWidget->getCurrentNumberOfTiles();
   if(numberOfSelectedTiles != numberOfMontageTiles)
   {
@@ -333,10 +341,23 @@ QString ImportGenericMontageDialog::getMontageName()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-std::tuple<int, int> ImportGenericMontageDialog::getMontageDimensions()
+IntVec3Type ImportGenericMontageDialog::getMontageStart()
 {
-  std::tuple<int, int> dims = std::make_tuple(m_Ui->numOfRowsSB->value(), m_Ui->numOfColsSB->value());
-  return dims;
+  int montageStartX = m_Ui->montageStartX->text().toInt();
+  int montageStartY = m_Ui->montageStartY->text().toInt();
+  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  return montageStart;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportGenericMontageDialog::getMontageEnd()
+{
+  int montageEndX = m_Ui->montageEndX->text().toInt();
+  int montageEndY = m_Ui->montageEndY->text().toInt();
+  IntVec3Type montageStart = {montageEndX, montageEndY, 1};
+  return montageStart;
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.h
@@ -35,8 +35,9 @@
 
 #pragma once
 
-#include "SIMPLVtkLib/Dialogs/AbstractImportMontageDialog.h"
+#include "SIMPLib/Common/SIMPLArray.hpp"
 
+#include "SIMPLVtkLib/Dialogs/AbstractImportMontageDialog.h"
 #include "SIMPLVtkLib/Dialogs/Utilities/MontageSettings.h"
 
 #include "ui_ImportGenericMontageDialog.h"
@@ -78,10 +79,16 @@ public:
   QString getMontageName();
 
   /**
-   * @brief getMontageDimensions
+   * @brief getMontageStart
    * @return
    */
-  std::tuple<int, int> getMontageDimensions();
+  IntVec3Type getMontageStart();
+
+  /**
+   * @brief getMontageEnd
+   * @return
+   */
+  IntVec3Type getMontageEnd();
 
   /**
    * @brief getTileOverlap

--- a/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportGenericMontageDialog.h
@@ -82,13 +82,13 @@ public:
    * @brief getMontageStart
    * @return
    */
-  IntVec3Type getMontageStart();
+  IntVec2Type getMontageStart();
 
   /**
    * @brief getMontageEnd
    * @return
    */
-  IntVec3Type getMontageEnd();
+  IntVec2Type getMontageEnd();
 
   /**
    * @brief getTileOverlap

--- a/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
@@ -88,6 +88,9 @@ void ImportZeissMontageDialog::setupGui()
 
   connectSignalsSlots();
 
+  SVStyle* style = SVStyle::Instance();
+  m_Ui->errLabel->setStyleSheet(tr("QLabel { color: %1; }").arg(style->getWidget_Error_color().name()));
+
   m_Ui->colorWeightingR->setValidator(new QDoubleValidator);
   m_Ui->colorWeightingG->setValidator(new QDoubleValidator);
   m_Ui->colorWeightingB->setValidator(new QDoubleValidator);
@@ -349,6 +352,25 @@ void ImportZeissMontageDialog::checkComplete() const
     }
   }
 
+  // Check that size of montage based on start and end is valid
+  int montageStartX = m_Ui->montageStartX->text().toInt();
+  int montageStartY = m_Ui->montageStartY->text().toInt();
+  int montageEndX = m_Ui->montageEndX->text().toInt();
+  int montageEndY = m_Ui->montageEndY->text().toInt();
+  int numCols = montageEndX - montageStartX + 1;
+  int numRows = montageEndY - montageStartY + 1;
+
+  int numberOfMontageTiles = numCols * numRows;
+  int numberOfSelectedTiles = m_Ui->zeissListWidget->getCurrentNumberOfTiles();
+  if(numberOfSelectedTiles < numberOfMontageTiles)
+  {
+    m_Ui->errLabel->setText(tr("The number of tiles in the tile list (%1) is less than the number of tiles declared in the montage (%2).\nPlease update"
+                               " the tile list as well as the 'Montage Start' and 'Montage End' fields.")
+                                .arg(numberOfSelectedTiles)
+                                .arg(numberOfMontageTiles));
+    result = false;
+  }
+
   QPushButton* okBtn = m_Ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
   if(okBtn == nullptr)
   {
@@ -356,6 +378,7 @@ void ImportZeissMontageDialog::checkComplete() const
   }
 
   okBtn->setEnabled(result);
+  m_Ui->errLabel->setVisible(!result);
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
@@ -432,22 +432,22 @@ FloatVec3Type ImportZeissMontageDialog::getOrigin()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportZeissMontageDialog::getMontageStart()
+IntVec2Type ImportZeissMontageDialog::getMontageStart()
 {
   int montageStartX = m_Ui->montageStartX->text().toFloat();
   int montageStartY = m_Ui->montageStartY->text().toFloat();
-  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  IntVec2Type montageStart = {montageStartX, montageStartY};
   return montageStart;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportZeissMontageDialog::getMontageEnd()
+IntVec2Type ImportZeissMontageDialog::getMontageEnd()
 {
   int montageEndX = m_Ui->montageEndX->text().toFloat();
   int montageEndY = m_Ui->montageEndY->text().toFloat();
-  IntVec3Type montageEnd = {montageEndX, montageEndY, 1};
+  IntVec2Type montageEnd = {montageEndX, montageEndY};
   return montageEnd;
 }
 

--- a/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
@@ -98,6 +98,11 @@ void ImportZeissMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
+  m_Ui->montageStartX->setValidator(new QDoubleValidator);
+  m_Ui->montageStartY->setValidator(new QDoubleValidator);
+  m_Ui->montageEndX->setValidator(new QDoubleValidator);
+  m_Ui->montageEndY->setValidator(new QDoubleValidator);
+
   m_Ui->montageNameLE->setText("Untitled Montage");
 
   setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
@@ -127,6 +132,11 @@ void ImportZeissMontageDialog::connectSignalsSlots()
   connect(m_Ui->spacingX, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->spacingY, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->spacingZ, &QLineEdit::textChanged, [=] { checkComplete(); });
+
+  connect(m_Ui->montageStartX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageStartY, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndY, &QLineEdit::textChanged, [=] { checkComplete(); });
 
   // Connect the checkboxes for grayscale, origin, and spacing to respective line edit group boxes
   connect(m_Ui->convertGrayscaleCB, &QCheckBox::stateChanged, [=] {
@@ -307,6 +317,38 @@ void ImportZeissMontageDialog::checkComplete() const
     }
   }
 
+  if(m_Ui->montageStartX->isEnabled())
+  {
+    if(m_Ui->montageStartX->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageStartY->isEnabled())
+  {
+    if(m_Ui->montageStartY->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageEndX->isEnabled())
+  {
+    if(m_Ui->montageEndX->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageEndY->isEnabled())
+  {
+    if(m_Ui->montageEndY->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
   QPushButton* okBtn = m_Ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
   if(okBtn == nullptr)
   {
@@ -362,6 +404,28 @@ FloatVec3Type ImportZeissMontageDialog::getOrigin()
   float originZ = m_Ui->originZ->text().toFloat();
   FloatVec3Type origin = {originX, originY, originZ};
   return origin;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportZeissMontageDialog::getMontageStart()
+{
+  int montageStartX = m_Ui->montageStartX->text().toFloat();
+  int montageStartY = m_Ui->montageStartY->text().toFloat();
+  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  return montageStart;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportZeissMontageDialog::getMontageEnd()
+{
+  int montageEndX = m_Ui->montageEndX->text().toFloat();
+  int montageEndY = m_Ui->montageEndY->text().toFloat();
+  IntVec3Type montageEnd = {montageEndX, montageEndY, 1};
+  return montageEnd;
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.cpp
@@ -98,6 +98,11 @@ void ImportZeissMontageDialog::setupGui()
   m_Ui->spacingY->setValidator(new QDoubleValidator);
   m_Ui->spacingZ->setValidator(new QDoubleValidator);
 
+  m_Ui->montageStartX->setValidator(new QDoubleValidator);
+  m_Ui->montageStartY->setValidator(new QDoubleValidator);
+  m_Ui->montageEndX->setValidator(new QDoubleValidator);
+  m_Ui->montageEndY->setValidator(new QDoubleValidator);
+
   m_Ui->montageNameLE->setText("Untitled Montage");
 
   setDisplayType(AbstractImportMontageDialog::DisplayType::Outline);
@@ -127,6 +132,11 @@ void ImportZeissMontageDialog::connectSignalsSlots()
   connect(m_Ui->spacingX, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->spacingY, &QLineEdit::textChanged, [=] { checkComplete(); });
   connect(m_Ui->spacingZ, &QLineEdit::textChanged, [=] { checkComplete(); });
+
+  connect(m_Ui->montageStartX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageStartY, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndX, &QLineEdit::textChanged, [=] { checkComplete(); });
+  connect(m_Ui->montageEndY, &QLineEdit::textChanged, [=] { checkComplete(); });
 
   // Connect the checkboxes for grayscale, origin, and spacing to respective line edit group boxes
   connect(m_Ui->convertGrayscaleCB, &QCheckBox::stateChanged, [=] {
@@ -188,13 +198,11 @@ void ImportZeissMontageDialog::changeOrigin_stateChanged(int state)
   m_Ui->originX->setEnabled(state);
   m_Ui->originY->setEnabled(state);
   m_Ui->originZ->setEnabled(state);
-  m_Ui->pixelCoordsCB->setEnabled(state);
   if(state == false)
   {
     m_Ui->originX->setText("0");
     m_Ui->originY->setText("0");
     m_Ui->originZ->setText("0");
-    m_Ui->pixelCoordsCB->setChecked(false);
   }
 }
 
@@ -309,6 +317,38 @@ void ImportZeissMontageDialog::checkComplete() const
     }
   }
 
+  if(m_Ui->montageStartX->isEnabled())
+  {
+    if(m_Ui->montageStartX->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageStartY->isEnabled())
+  {
+    if(m_Ui->montageStartY->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageEndX->isEnabled())
+  {
+    if(m_Ui->montageEndX->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
+  if(m_Ui->montageEndY->isEnabled())
+  {
+    if(m_Ui->montageEndY->text().isEmpty())
+    {
+      result = false;
+    }
+  }
+
   QPushButton* okBtn = m_Ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
   if(!okBtn)
   {
@@ -364,6 +404,28 @@ FloatVec3Type ImportZeissMontageDialog::getOrigin()
   float originZ = m_Ui->originZ->text().toFloat();
   FloatVec3Type origin = {originX, originY, originZ};
   return origin;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportZeissMontageDialog::getMontageStart()
+{
+  int montageStartX = m_Ui->montageStartX->text().toFloat();
+  int montageStartY = m_Ui->montageStartY->text().toFloat();
+  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  return montageStart;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+IntVec3Type ImportZeissMontageDialog::getMontageEnd()
+{
+  int montageEndX = m_Ui->montageEndX->text().toFloat();
+  int montageEndY = m_Ui->montageEndY->text().toFloat();
+  IntVec3Type montageEnd = {montageEndX, montageEndY, 1};
+  return montageEnd;
 }
 
 // -----------------------------------------------------------------------------

--- a/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.h
@@ -105,13 +105,13 @@ public:
    * @brief getMontageStart
    * @return
    */
-  IntVec3Type getMontageStart();
+  IntVec2Type getMontageStart();
 
   /**
    * @brief getMontageEnd
    * @return
    */
-  IntVec3Type getMontageEnd();
+  IntVec2Type getMontageEnd();
 
   /**
    * @brief getConvertToGrayscale
@@ -143,7 +143,7 @@ protected slots:
   void zeissListWidgetChanged();
 
 protected:
-  static void setOpenDialogLastFilePath(const QString &val)
+  static void setOpenDialogLastFilePath(const QString& val)
   {
     m_OpenDialogLastDirectory = val;
   }

--- a/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportZeissMontageDialog.h
@@ -102,6 +102,18 @@ public:
   FloatVec3Type getOrigin();
 
   /**
+   * @brief getMontageStart
+   * @return
+   */
+  IntVec3Type getMontageStart();
+
+  /**
+   * @brief getMontageEnd
+   * @return
+   */
+  IntVec3Type getMontageEnd();
+
+  /**
    * @brief getConvertToGrayscale
    * @return
    */

--- a/SIMPLVtkLib/Dialogs/ImportZeissZenMontageDialog.cpp
+++ b/SIMPLVtkLib/Dialogs/ImportZeissZenMontageDialog.cpp
@@ -321,7 +321,6 @@ void ImportZeissZenMontageDialog::checkComplete() const
     result = false;
   }
 
-
   QPushButton* okBtn = m_Ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
   if(okBtn == nullptr)
   {
@@ -383,21 +382,21 @@ FloatVec3Type ImportZeissZenMontageDialog::getColorWeighting()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportZeissZenMontageDialog::getMontageStart()
+IntVec2Type ImportZeissZenMontageDialog::getMontageStart()
 {
   int montageStartX = m_Ui->montageStartX->text().toInt();
   int montageStartY = m_Ui->montageStartY->text().toInt();
-  IntVec3Type montageStart = {montageStartX, montageStartY, 1};
+  IntVec2Type montageStart = {montageStartX, montageStartY};
   return montageStart;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-IntVec3Type ImportZeissZenMontageDialog::getMontageEnd()
+IntVec2Type ImportZeissZenMontageDialog::getMontageEnd()
 {
   int montageEndX = m_Ui->montageEndX->text().toInt();
   int montageEndY = m_Ui->montageEndY->text().toInt();
-  IntVec3Type montageEnd = {montageEndX, montageEndY, 1};
+  IntVec2Type montageEnd = {montageEndX, montageEndY};
   return montageEnd;
 }

--- a/SIMPLVtkLib/Dialogs/ImportZeissZenMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportZeissZenMontageDialog.h
@@ -101,6 +101,18 @@ public:
    */
   FloatVec3Type getColorWeighting();
 
+  /**
+   * @brief getMontageStart
+   * @return
+   */
+  IntVec3Type getMontageStart();
+
+  /**
+   * @brief getMontageEnd
+   * @return
+   */
+  IntVec3Type getMontageEnd();
+
 protected:
   /**
    * @brief Constructor

--- a/SIMPLVtkLib/Dialogs/ImportZeissZenMontageDialog.h
+++ b/SIMPLVtkLib/Dialogs/ImportZeissZenMontageDialog.h
@@ -105,13 +105,13 @@ public:
    * @brief getMontageStart
    * @return
    */
-  IntVec3Type getMontageStart();
+  IntVec2Type getMontageStart();
 
   /**
    * @brief getMontageEnd
    * @return
    */
-  IntVec3Type getMontageEnd();
+  IntVec2Type getMontageEnd();
 
 protected:
   /**
@@ -130,7 +130,7 @@ protected slots:
   void zeissListWidgetChanged();
 
 protected:
-  static void setOpenDialogLastFilePath(const QString &val)
+  static void setOpenDialogLastFilePath(const QString& val)
   {
     m_OpenDialogLastDirectory = val;
   }

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportFijiMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportFijiMontageDialog.ui
@@ -203,28 +203,28 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLineEdit" name="lineEdit">
+      <widget class="QLineEdit" name="montageStartX">
        <property name="text">
         <string>0</string>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLineEdit" name="lineEdit_2">
+      <widget class="QLineEdit" name="montageStartY">
        <property name="text">
         <string>0</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLineEdit" name="lineEdit_3">
+      <widget class="QLineEdit" name="montageEndX">
        <property name="text">
         <string>0</string>
        </property>
       </widget>
      </item>
      <item row="1" column="2">
-      <widget class="QLineEdit" name="lineEdit_4">
+      <widget class="QLineEdit" name="montageEndY">
        <property name="text">
         <string>0</string>
        </property>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportFijiMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportFijiMontageDialog.ui
@@ -26,88 +26,7 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="changeSpacingCB">
-     <property name="text">
-      <string>Override Spacing (X, Y, Z)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Data Display Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="originX">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QLineEdit" name="spacingY">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="spacingX">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QCheckBox" name="changeOriginCB">
-     <property name="text">
-      <string>Override Origin (X, Y, Z)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLineEdit" name="originY">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3">
-    <widget class="QLineEdit" name="originZ">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="3">
-    <widget class="QLineEdit" name="spacingZ">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
+   <item row="8" column="1">
     <widget class="QComboBox" name="dataDisplayTypeCB">
      <item>
       <property name="text">
@@ -126,37 +45,20 @@
      </item>
     </widget>
    </item>
-   <item row="7" column="0" colspan="5">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_17">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Montage Name</string>
+      <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QLineEdit" name="montageNameLE">
-     <property name="text">
-      <string>Untitled Montage</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="4">
-    <widget class="QCheckBox" name="pixelCoordsCB">
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="spacingY">
      <property name="enabled">
       <bool>false</bool>
      </property>
      <property name="text">
-      <string>Pixel Coordinates</string>
+      <string>1</string>
      </property>
     </widget>
    </item>
@@ -170,15 +72,158 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="2" column="3">
+    <widget class="QLineEdit" name="originZ">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Data Display Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Length Units</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_17">
+     <property name="text">
+      <string>Montage Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="spacingX">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="originX">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="changeSpacingCB">
+     <property name="text">
+      <string>Override Spacing (X, Y, Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
     <widget class="QComboBox" name="unitsCB"/>
+   </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QLineEdit" name="montageNameLE">
+     <property name="text">
+      <string>Untitled Montage</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="5">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="originY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QLineEdit" name="spacingZ">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="changeOriginCB">
+     <property name="text">
+      <string>Override Origin (X, Y, Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QCheckBox" name="pixelCoordsCB">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Pixel Coordinates</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
+    <widget class="QLineEdit" name="montageEndY">
+     <property name="inputMask">
+      <string/>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLineEdit" name="montageStartY">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLineEdit" name="montageEndX">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="montageStartX">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportFijiMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportFijiMontageDialog.ui
@@ -88,7 +88,81 @@
    </item>
    <item row="2" column="0" colspan="5">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="0" column="4">
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="spacingX">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="QLineEdit" name="spacingZ">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLineEdit" name="originY">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="changeSpacingCB">
+       <property name="text">
+        <string>Override Spacing (X, Y, Z)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QLineEdit" name="spacingY">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QLineEdit" name="originZ">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="originX">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -101,82 +175,76 @@
        </property>
       </spacer>
      </item>
-     <item row="0" column="0">
+     <item row="2" column="0">
       <widget class="QCheckBox" name="changeOriginCB">
        <property name="text">
         <string>Override Origin (X, Y, Z)</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="originX">
-       <property name="enabled">
-        <bool>false</bool>
+     <item row="3" column="4">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>0</string>
+        <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
-      <widget class="QLineEdit" name="originZ">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="lineEdit">
        <property name="text">
         <string>0</string>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLineEdit" name="originY">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
+      <widget class="QLineEdit" name="lineEdit_2">
        <property name="text">
         <string>0</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="changeSpacingCB">
-       <property name="text">
-        <string>Override Spacing (X, Y, Z)</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1">
-      <widget class="QLineEdit" name="spacingX">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
+      <widget class="QLineEdit" name="lineEdit_3">
        <property name="text">
-        <string>1</string>
+        <string>0</string>
        </property>
       </widget>
      </item>
      <item row="1" column="2">
-      <widget class="QLineEdit" name="spacingY">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
+      <widget class="QLineEdit" name="lineEdit_4">
        <property name="text">
-        <string>1</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="3">
-      <widget class="QLineEdit" name="spacingZ">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>1</string>
+        <string>0</string>
        </property>
       </widget>
      </item>
      <item row="1" column="4">
-      <spacer name="horizontalSpacer_2">
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="4">
+      <spacer name="horizontalSpacer_4">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportFijiMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportFijiMontageDialog.ui
@@ -268,6 +268,13 @@
    <item row="3" column="2">
     <widget class="QComboBox" name="unitsCB"/>
    </item>
+   <item row="6" column="0" colspan="4">
+    <widget class="QLabel" name="errLabel">
+     <property name="text">
+      <string>Error Label</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportGenericMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportGenericMontageDialog.ui
@@ -26,116 +26,7 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="7" column="0">
-    <widget class="QCheckBox" name="changeSpacingCB">
-     <property name="text">
-      <string>Override Spacing (X, Y, Z)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QComboBox" name="orderCB"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Total Rows</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="4">
-    <widget class="QLabel" name="errLabel">
-     <property name="text">
-      <string>Error Label</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Data Display Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QLineEdit" name="spacingX">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="3">
-    <widget class="QLineEdit" name="spacingZ">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="5">
-    <widget class="TileListWidget" name="tileListWidget" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Order</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="5">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Total Columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QLineEdit" name="originZ">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Origin (X, Y, Z)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Collection Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
+   <item row="11" column="1">
     <widget class="QComboBox" name="dataDisplayTypeCB">
      <item>
       <property name="text">
@@ -154,30 +45,6 @@
      </item>
     </widget>
    </item>
-   <item row="4" column="2">
-    <widget class="QLineEdit" name="originY">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3">
-    <widget class="QSpinBox" name="numOfColsSB">
-     <property name="value">
-      <number>5</number>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QLineEdit" name="montageNameLE">
-     <property name="text">
-      <string>Untitled Montage</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_17">
      <property name="text">
@@ -185,8 +52,8 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <widget class="QLineEdit" name="spacingY">
+   <item row="8" column="2">
+    <widget class="QLineEdit" name="spacingX">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -195,40 +62,10 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QSpinBox" name="tileOverlapSB">
-     <property name="suffix">
-      <string>%</string>
-     </property>
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="value">
-      <number>15</number>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="originX">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+   <item row="8" column="0">
+    <widget class="QCheckBox" name="changeSpacingCB">
      <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Tile Overlap</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QSpinBox" name="numOfRowsSB">
-     <property name="value">
-      <number>6</number>
+      <string>Override Spacing (X, Y, Z)</string>
      </property>
     </widget>
    </item>
@@ -264,15 +101,192 @@
      </item>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="9" column="0" colspan="5">
+    <widget class="TileListWidget" name="tileListWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Tile Overlap</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="originX">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
     <widget class="QLabel" name="label_6">
      <property name="text">
       <string>Length Units</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="10" column="1">
     <widget class="QComboBox" name="unitsCB"/>
+   </item>
+   <item row="12" column="0" colspan="4">
+    <widget class="QLabel" name="errLabel">
+     <property name="text">
+      <string>Error Label</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLineEdit" name="originY">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Order</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="3">
+    <widget class="QLineEdit" name="originZ">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Collection Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0" colspan="5">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="3">
+    <widget class="QLineEdit" name="spacingZ">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QSpinBox" name="tileOverlapSB">
+     <property name="suffix">
+      <string>%</string>
+     </property>
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>15</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QComboBox" name="orderCB"/>
+   </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QLineEdit" name="montageNameLE">
+     <property name="text">
+      <string>Untitled Montage</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Origin (X, Y, Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Data Display Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QLineEdit" name="spacingY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="montageStartX">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="montageStartY">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="montageEndX">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="montageEndY">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportGenericMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportGenericMontageDialog.ui
@@ -26,7 +26,65 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="6" column="1">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Collection Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QComboBox" name="unitsCB"/>
+   </item>
+   <item row="8" column="2">
+    <widget class="QLineEdit" name="spacingX">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Origin (X, Y, Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QLineEdit" name="spacingY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="4">
+    <widget class="QLabel" name="errLabel">
+     <property name="text">
+      <string>Error Label</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="montageStartY">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
     <widget class="QSpinBox" name="tileOverlapSB">
      <property name="suffix">
       <string>%</string>
@@ -39,64 +97,11 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
-    <widget class="QLineEdit" name="spacingX">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Collection Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Data Display Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3">
-    <widget class="QLineEdit" name="originZ">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="montageEndX">
      <property name="text">
       <string>0</string>
      </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Tile Overlap</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <widget class="QComboBox" name="dataDisplayTypeCB">
-     <item>
-      <property name="text">
-       <string>Outline Only</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Individual Tiles</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Stitched Montage</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="1" column="1">
@@ -131,24 +136,48 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QLineEdit" name="montageNameLE">
-     <property name="text">
-      <string>Untitled Montage</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QLineEdit" name="spacingY">
+   <item row="5" column="4">
+    <widget class="QCheckBox" name="pixelCoordsCB">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="text">
-      <string>1</string>
+      <string>Pixel Coordinates</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="3">
+   <item row="5" column="3">
+    <widget class="QLineEdit" name="originZ">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Tile Overlap</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QCheckBox" name="changeSpacingCB">
+     <property name="text">
+      <string>Override Spacing (X, Y, Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Data Display Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="3">
     <widget class="QLineEdit" name="spacingZ">
      <property name="enabled">
       <bool>false</bool>
@@ -158,30 +187,73 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="0" colspan="5">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="9" column="0" colspan="5">
+    <widget class="TileListWidget" name="tileListWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QCheckBox" name="changeSpacingCB">
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Override Spacing (X, Y, Z)</string>
+      <string>Length Units</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="4">
-    <widget class="QCheckBox" name="pixelCoordsCB">
+   <item row="4" column="2">
+    <widget class="QLineEdit" name="montageEndY">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <widget class="QComboBox" name="dataDisplayTypeCB">
+     <item>
+      <property name="text">
+       <string>Outline Only</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Individual Tiles</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Stitched Montage</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="originX">
      <property name="enabled">
       <bool>true</bool>
      </property>
      <property name="text">
-      <string>Pixel Coordinates</string>
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLineEdit" name="originY">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QLineEdit" name="montageNameLE">
+     <property name="text">
+      <string>Untitled Montage</string>
      </property>
     </widget>
    </item>
@@ -192,37 +264,23 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="2">
-    <widget class="QLineEdit" name="originY">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+   <item row="1" column="3">
+    <widget class="QComboBox" name="orderCB"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>0</string>
+      <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="0" colspan="4">
-    <widget class="QLabel" name="errLabel">
-     <property name="text">
-      <string>Error Label</string>
+   <item row="13" column="0" colspan="5">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Origin (X, Y, Z)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="originX">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>0</string>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -233,54 +291,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
-    <widget class="QComboBox" name="orderCB"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Total Rows</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
-    <widget class="QSpinBox" name="numOfRowsSB">
-     <property name="value">
-      <number>6</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLineEdit" name="montageStartX">
      <property name="text">
-      <string>Total Columns</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3">
-    <widget class="QSpinBox" name="numOfColsSB">
-     <property name="value">
-      <number>5</number>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="5">
-    <widget class="TileListWidget" name="tileListWidget" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QComboBox" name="unitsCB"/>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Length Units</string>
+      <string>0</string>
      </property>
     </widget>
    </item>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportZeissMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportZeissMontageDialog.ui
@@ -26,17 +26,10 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="4" column="0">
-    <widget class="QCheckBox" name="convertGrayscaleCB">
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="montageStartY">
      <property name="text">
-      <string>Convert to Grayscale (RGB Weighting)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_17">
-     <property name="text">
-      <string>Montage Name</string>
+      <string>0</string>
      </property>
     </widget>
    </item>
@@ -72,68 +65,27 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="2" colspan="2">
-    <widget class="QLineEdit" name="originY">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="changeOriginCB">
      <property name="text">
-      <string>0</string>
+      <string>Override Origin (X,Y,Z)</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="2" colspan="2">
-    <widget class="QLineEdit" name="colorWeightingG">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0.7154</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="4">
-    <widget class="QLineEdit" name="spacingZ">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="5">
+   <item row="9" column="0" colspan="5">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
      </property>
     </widget>
    </item>
@@ -153,6 +105,36 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_17">
+     <property name="text">
+      <string>Montage Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QLineEdit" name="montageNameLE">
+     <property name="text">
+      <string>Untitled Montage</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2" colspan="2">
+    <widget class="QLineEdit" name="colorWeightingG">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.7154</string>
+     </property>
+    </widget>
+   </item>
    <item row="7" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
@@ -160,10 +142,43 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QCheckBox" name="changeSpacingCB">
+   <item row="1" column="0" colspan="5">
+    <widget class="ZeissListWidget" name="zeissListWidget" native="true"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="montageEndX">
      <property name="text">
-      <string>Override Spacing (X,Y,Z)</string>
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="4">
+    <widget class="QLineEdit" name="spacingZ">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="convertGrayscaleCB">
+     <property name="text">
+      <string>Convert to Grayscale (RGB Weighting)</string>
      </property>
     </widget>
    </item>
@@ -183,8 +198,8 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="4">
-    <widget class="QLineEdit" name="colorWeightingB">
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="originX">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -195,7 +210,7 @@
       </size>
      </property>
      <property name="text">
-      <string>0.0721</string>
+      <string>0</string>
      </property>
     </widget>
    </item>
@@ -218,25 +233,22 @@
      </item>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QCheckBox" name="changeOriginCB">
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="montageStartX">
      <property name="text">
-      <string>Override Origin (X,Y,Z)</string>
+      <string>0</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QLineEdit" name="montageNameLE">
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="montageEndY">
      <property name="text">
-      <string>Untitled Montage</string>
+      <string>0</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="5">
-    <widget class="ZeissListWidget" name="zeissListWidget" native="true"/>
-   </item>
-   <item row="5" column="1">
-    <widget class="QLineEdit" name="originX">
+   <item row="5" column="2" colspan="2">
+    <widget class="QLineEdit" name="originY">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -251,38 +263,33 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="6" column="0">
+    <widget class="QCheckBox" name="changeSpacingCB">
      <property name="text">
-      <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
+      <string>Override Spacing (X,Y,Z)</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="montageStartX">
+   <item row="4" column="4">
+    <widget class="QLineEdit" name="colorWeightingB">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
      <property name="text">
-      <string>0</string>
+      <string>0.0721</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QLineEdit" name="montageStartY">
+   <item row="8" column="0" colspan="5">
+    <widget class="QLabel" name="errLabel">
      <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="montageEndX">
-     <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QLineEdit" name="montageEndY">
-     <property name="text">
-      <string>0</string>
+      <string>Error Label</string>
      </property>
     </widget>
    </item>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportZeissMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportZeissMontageDialog.ui
@@ -26,14 +26,7 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="4" column="0">
-    <widget class="QCheckBox" name="changeSpacingCB">
-     <property name="text">
-      <string>Override Spacing (X,Y,Z)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
+   <item row="5" column="1">
     <widget class="QLineEdit" name="originX">
      <property name="enabled">
       <bool>false</bool>
@@ -49,177 +42,8 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <widget class="QLineEdit" name="originY">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="changeOriginCB">
-     <property name="text">
-      <string>Override Origin (X,Y,Z)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QComboBox" name="dataDisplayTypeCB">
-     <item>
-      <property name="text">
-       <string>Outline Only</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Individual Tiles</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Stitched Montage</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="3" column="3">
-    <widget class="QLineEdit" name="originZ">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Data Display Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QCheckBox" name="convertGrayscaleCB">
-     <property name="text">
-      <string>Convert to Grayscale (RGB Weighting)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
+   <item row="6" column="1">
     <widget class="QLineEdit" name="spacingX">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_17">
-     <property name="text">
-      <string>Montage Name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="colorWeightingR">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0.2125</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="4">
-    <widget class="QCheckBox" name="pixelCoordsCB">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Pixel Coordinates</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="4">
-    <widget class="QLineEdit" name="colorWeightingB">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0.0721</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2" colspan="2">
-    <widget class="QLineEdit" name="colorWeightingG">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0.7154</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="4">
-    <widget class="QLineEdit" name="spacingZ">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2" colspan="2">
-    <widget class="QLineEdit" name="spacingY">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -241,16 +65,234 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="5">
-    <widget class="ZeissListWidget" name="zeissListWidget" native="true"/>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="colorWeightingR">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.2125</string>
+     </property>
+    </widget>
    </item>
-   <item row="6" column="0" colspan="5">
+   <item row="4" column="2" colspan="2">
+    <widget class="QLineEdit" name="colorWeightingG">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.7154</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QCheckBox" name="changeSpacingCB">
+     <property name="text">
+      <string>Override Spacing (X,Y,Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="changeOriginCB">
+     <property name="text">
+      <string>Override Origin (X,Y,Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLineEdit" name="originY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="convertGrayscaleCB">
+     <property name="text">
+      <string>Convert to Grayscale (RGB Weighting)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="4">
+    <widget class="QCheckBox" name="pixelCoordsCB">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Pixel Coordinates</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="4">
+    <widget class="QLineEdit" name="colorWeightingB">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.0721</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Data Display Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="5">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_17">
+     <property name="text">
+      <string>Montage Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="montageStartX">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2" colspan="2">
+    <widget class="QLineEdit" name="spacingY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="4">
+    <widget class="QLineEdit" name="spacingZ">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QComboBox" name="dataDisplayTypeCB">
+     <item>
+      <property name="text">
+       <string>Outline Only</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Individual Tiles</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Stitched Montage</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="3">
+    <widget class="QLineEdit" name="originZ">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="5">
+    <widget class="ZeissListWidget" name="zeissListWidget" native="true"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="montageEndX">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2" colspan="2">
+    <widget class="QLineEdit" name="montageEndY">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2" colspan="2">
+    <widget class="QLineEdit" name="montageStartY">
+     <property name="text">
+      <string>0</string>
      </property>
     </widget>
    </item>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportZeissMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportZeissMontageDialog.ui
@@ -27,14 +27,37 @@
     <number>6</number>
    </property>
    <item row="4" column="0">
-    <widget class="QCheckBox" name="changeSpacingCB">
+    <widget class="QCheckBox" name="convertGrayscaleCB">
      <property name="text">
-      <string>Override Spacing (X,Y,Z)</string>
+      <string>Convert to Grayscale (RGB Weighting)</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="originX">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_17">
+     <property name="text">
+      <string>Montage Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLineEdit" name="spacingX">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="4">
+    <widget class="QLineEdit" name="originZ">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -49,14 +72,134 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="changeOriginCB">
+   <item row="5" column="2" colspan="2">
+    <widget class="QLineEdit" name="originY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
      <property name="text">
-      <string>Override Origin (X,Y,Z)</string>
+      <string>0</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="4" column="2" colspan="2">
+    <widget class="QLineEdit" name="colorWeightingG">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.7154</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="4">
+    <widget class="QLineEdit" name="spacingZ">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="5">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2" colspan="2">
+    <widget class="QLineEdit" name="spacingY">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Data Display Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QCheckBox" name="changeSpacingCB">
+     <property name="text">
+      <string>Override Spacing (X,Y,Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="colorWeightingR">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.2125</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="4">
+    <widget class="QLineEdit" name="colorWeightingB">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.0721</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
     <widget class="QComboBox" name="dataDisplayTypeCB">
      <item>
       <property name="text">
@@ -76,119 +219,9 @@
     </widget>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="label_7">
+    <widget class="QCheckBox" name="changeOriginCB">
      <property name="text">
-      <string>Data Display Type</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QCheckBox" name="convertGrayscaleCB">
-     <property name="text">
-      <string>Convert to Grayscale (RGB Weighting)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="spacingX">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_17">
-     <property name="text">
-      <string>Montage Name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="colorWeightingR">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0.2125</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="4">
-    <widget class="QLineEdit" name="colorWeightingB">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0.0721</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2" colspan="2">
-    <widget class="QLineEdit" name="colorWeightingG">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>0.7154</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="4">
-    <widget class="QLineEdit" name="spacingZ">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>1</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="2" colspan="2">
-    <widget class="QLineEdit" name="spacingY">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>1</string>
+      <string>Override Origin (X,Y,Z)</string>
      </property>
     </widget>
    </item>
@@ -202,18 +235,8 @@
    <item row="1" column="0" colspan="5">
     <widget class="ZeissListWidget" name="zeissListWidget" native="true"/>
    </item>
-   <item row="6" column="0" colspan="5">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="4">
-    <widget class="QLineEdit" name="originZ">
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="originX">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -228,17 +251,36 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2" colspan="2">
-    <widget class="QLineEdit" name="originY">
-     <property name="enabled">
-      <bool>false</bool>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="montageStartX">
+     <property name="text">
+      <string>0</string>
      </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="montageStartY">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="montageEndX">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="montageEndY">
      <property name="text">
       <string>0</string>
      </property>

--- a/SIMPLVtkLib/Dialogs/UI_Files/ImportZeissZenMontageDialog.ui
+++ b/SIMPLVtkLib/Dialogs/UI_Files/ImportZeissZenMontageDialog.ui
@@ -26,31 +26,43 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="colorWeightingR">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="montageStartY">
      <property name="text">
-      <string>0.2125</string>
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Montage Start (Col, Row) [Inclusive, Zero Based]</string>
      </property>
     </widget>
    </item>
    <item row="4" column="0">
+    <widget class="QCheckBox" name="convertGrayscaleCB">
+     <property name="text">
+      <string>Convert to Grayscale (RGB Weighting)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>Data Display Type</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="2" colspan="2">
-    <widget class="QLineEdit" name="originY">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_17">
+     <property name="text">
+      <string>Montage Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2" colspan="2">
+    <widget class="QLineEdit" name="colorWeightingG">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -60,24 +72,22 @@
        <height>21</height>
       </size>
      </property>
+     <property name="text">
+      <string>0.7154</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="montageEndX">
      <property name="text">
       <string>0</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="4">
-    <widget class="QLineEdit" name="colorWeightingB">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>56</width>
-       <height>21</height>
-      </size>
-     </property>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>0.0721</string>
+      <string>Montage End (Col, Row) [Inclusive, Zero Based]</string>
      </property>
     </widget>
    </item>
@@ -88,17 +98,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="5">
-    <widget class="ZeissZenListWidget" name="zeissListWidget" native="true"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QCheckBox" name="convertGrayscaleCB">
-     <property name="text">
-      <string>Convert to Grayscale (RGB Weighting)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="4">
+   <item row="5" column="4">
     <widget class="QLineEdit" name="originZ">
      <property name="enabled">
       <bool>false</bool>
@@ -114,8 +114,15 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="originX">
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="montageStartX">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2" colspan="2">
+    <widget class="QLineEdit" name="originY">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -130,7 +137,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="6" column="1">
     <widget class="QComboBox" name="dataDisplayTypeCB">
      <item>
       <property name="text">
@@ -149,22 +156,25 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_17">
+   <item row="3" column="2">
+    <widget class="QLineEdit" name="montageEndY">
      <property name="text">
-      <string>Montage Name</string>
+      <string>0</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="changeOriginCB">
-     <property name="text">
-      <string>Override Origin (X,Y,Z)</string>
+   <item row="8" column="0" colspan="5">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="2" column="2" colspan="2">
-    <widget class="QLineEdit" name="colorWeightingG">
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="originX">
      <property name="enabled">
       <bool>false</bool>
      </property>
@@ -175,17 +185,56 @@
       </size>
      </property>
      <property name="text">
-      <string>0.7154</string>
+      <string>0</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="5">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="4" column="4">
+    <widget class="QLineEdit" name="colorWeightingB">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.0721</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="5">
+    <widget class="ZeissZenListWidget" name="zeissListWidget" native="true"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="changeOriginCB">
+     <property name="text">
+      <string>Override Origin (X,Y,Z)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="colorWeightingR">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>56</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0.2125</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="5">
+    <widget class="QLabel" name="errLabel">
+     <property name="text">
+      <string>Error Label</string>
      </property>
     </widget>
    </item>

--- a/SIMPLVtkLib/Dialogs/ZeissListWidget.cpp
+++ b/SIMPLVtkLib/Dialogs/ZeissListWidget.cpp
@@ -479,3 +479,11 @@ QString ZeissListWidget::getInputDirectory()
   }
   return m_Ui->inputDir->text();
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+int ZeissListWidget::getCurrentNumberOfTiles()
+{
+  return m_Ui->fileListView->count();
+}

--- a/SIMPLVtkLib/Dialogs/ZeissListWidget.cpp
+++ b/SIMPLVtkLib/Dialogs/ZeissListWidget.cpp
@@ -373,7 +373,7 @@ QStringList ZeissListWidget::readZeissConfigFile()
       // Set the Data Container Prefix
       QString dataContainerPrefix = "DataContainer";
       var.setValue(DataArrayPath(dataContainerPrefix, "", ""));
-      if(!importZeissMontageFilter->setProperty("DataContainerName", var))
+      if(!importZeissMontageFilter->setProperty("DataContainerPath", var))
       {
         return fileNameList;
       }
@@ -410,7 +410,7 @@ QStringList ZeissListWidget::readZeissConfigFile()
       }
 
       importZeissMontageFilter->preflight();
-      fileNameList = importZeissMontageFilter->property("FilenameList").toStringList();
+      fileNameList = importZeissMontageFilter->property("GeneratedFileList").toStringList();
     }
   }
 

--- a/SIMPLVtkLib/Dialogs/ZeissListWidget.h
+++ b/SIMPLVtkLib/Dialogs/ZeissListWidget.h
@@ -118,6 +118,12 @@ public:
    */
   ZeissListInfo_t getZeissListInfo();
 
+  /**
+   * @brief getCurrentNumberOfTiles
+   * @return
+   */
+  int getCurrentNumberOfTiles();
+
 protected slots:
 
   // Slots to catch signals emitted by the various ui widgets

--- a/SIMPLVtkLib/Dialogs/ZeissZenListWidget.cpp
+++ b/SIMPLVtkLib/Dialogs/ZeissZenListWidget.cpp
@@ -464,3 +464,11 @@ QString ZeissZenListWidget::getInputDirectory()
   }
   return m_Ui->inputDir->text();
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+int ZeissZenListWidget::getCurrentNumberOfTiles()
+{
+  return m_Ui->fileListView->count();
+}

--- a/SIMPLVtkLib/Dialogs/ZeissZenListWidget.h
+++ b/SIMPLVtkLib/Dialogs/ZeissZenListWidget.h
@@ -118,6 +118,12 @@ public:
    */
   ZeissZenListInfo_t getZeissZenListInfo();
 
+  /**
+   * @brief getCurrentNumberOfTiles
+   * @return
+   */
+  int getCurrentNumberOfTiles();
+
 protected slots:
 
   // Slots to catch signals emitted by the various ui widgets

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
@@ -501,10 +501,10 @@ AbstractFilter::Pointer VSFilterFactory::createImportZeissZenMontageFilter(const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AbstractFilter::Pointer VSFilterFactory::createImportZeissMontageFilter(const QString& zeissFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName,
-                                                                        const QString &metaAmName, bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights,
-                                                                        bool changeOrigin, FloatVec3Type origin, bool changeSpacing, FloatVec3Type spacing)
-{
+AbstractFilter::Pointer VSFilterFactory::createImportZeissMontageFilter(const QString& zeissFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, const QString& metaAmName,
+                                                                        bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin,
+                                                                        IntVec3Type montageStart, IntVec3Type montageEnd, bool changeSpacing, FloatVec3Type spacing)
+  {
   // Instantiate Import AxioVision V4 Montage filter
   QString filterName = "ImportAxioVisionV4Montage";
   FilterManager* fm = FilterManager::Instance();

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
@@ -40,6 +40,7 @@
 
 #include "SIMPLib/DataContainers/DataContainerArrayProxy.h"
 #include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
+#include "SIMPLib/FilterParameters/IntVec2FilterParameter.h"
 #include "SIMPLib/Filtering/FilterFactory.hpp"
 #include "SIMPLib/Filtering/FilterManager.h"
 
@@ -54,7 +55,7 @@ VSFilterFactory::VSFilterFactory(QObject* parent)
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AbstractFilter::Pointer VSFilterFactory::createDataContainerReaderFilter(const QString& inputFile, const DataContainerArrayProxy &inputFileDCAProxy)
+AbstractFilter::Pointer VSFilterFactory::createDataContainerReaderFilter(const QString& inputFile, const DataContainerArrayProxy& inputFileDCAProxy)
 {
   QString filterName = "DataContainerReader";
   FilterManager* fm = FilterManager::Instance();
@@ -189,7 +190,8 @@ AbstractFilter::Pointer VSFilterFactory::createSetOriginResolutionFilter(const D
 //
 // -----------------------------------------------------------------------------
 AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QString& fijiFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, bool changeOrigin,
-                                                                       const float* origin, IntVec3Type montageStart, IntVec3Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit)
+                                                                       const float* origin, IntVec2Type montageStart, IntVec2Type montageEnd, bool changeSpacing, const float* spacing,
+                                                                       int32_t lengthUnit)
 {
   QString filterName = "ITKImportFijiMontage";
   FilterManager* fm = FilterManager::Instance();
@@ -205,6 +207,20 @@ AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QSt
       // Set the path for the Fiji Configuration File
       var.setValue(fijiFile);
       if(!setFilterProperty(importFijiMontageFilter, "InputFile", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage start
+      var.setValue(montageStart);
+      if(!setFilterProperty(importFijiMontageFilter, "MontageStart", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage end
+      var.setValue(montageEnd);
+      if(!setFilterProperty(importFijiMontageFilter, "MontageEnd", var))
       {
         return AbstractFilter::NullPointer();
       }
@@ -289,7 +305,7 @@ AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QSt
 // -----------------------------------------------------------------------------
 AbstractFilter::Pointer VSFilterFactory::createImportRobometMontageFilter(const QString& robometFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, int sliceNumber,
                                                                           const QString& imageFilePrefix, const QString& imageFileExtension, bool changeOrigin, const float* origin,
-                                                                          bool changeSpacing, const float* spacing, int32_t lengthUnit)
+                                                                          IntVec2Type montageStart, IntVec2Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit)
 {
   QString filterName = "ITKImportRoboMetMontage";
   FilterManager* fm = FilterManager::Instance();
@@ -305,6 +321,20 @@ AbstractFilter::Pointer VSFilterFactory::createImportRobometMontageFilter(const 
       // Set the path for the Robomet Configuration File
       var.setValue(robometFile);
       if(!setFilterProperty(importRoboMetMontageFilter, "InputFile", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage start
+      var.setValue(montageStart);
+      if(!setFilterProperty(importRoboMetMontageFilter, "MontageStart", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage end
+      var.setValue(montageEnd);
+      if(!setFilterProperty(importRoboMetMontageFilter, "MontageEnd", var))
       {
         return AbstractFilter::NullPointer();
       }
@@ -409,7 +439,7 @@ AbstractFilter::Pointer VSFilterFactory::createImportRobometMontageFilter(const 
 //
 // -----------------------------------------------------------------------------
 AbstractFilter::Pointer VSFilterFactory::createImportZeissZenMontageFilter(const QString& zeissFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, bool convertToGrayscale,
-                                                                           FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin)
+                                                                           FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin, IntVec2Type montageStart, IntVec2Type montageEnd)
 {
   // Instantiate Import AxioVision V4 Montage filter
   QString filterName = "ImportZenInfoMontage";
@@ -426,6 +456,20 @@ AbstractFilter::Pointer VSFilterFactory::createImportZeissZenMontageFilter(const
       // Set the path for the Zeiss Zen File
       var.setValue(zeissFile);
       if(!setFilterProperty(importZeissZenMontageFilter, "InputFile", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage start
+      var.setValue(montageStart);
+      if(!setFilterProperty(importZeissZenMontageFilter, "MontageStart", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage end
+      var.setValue(montageEnd);
+      if(!setFilterProperty(importZeissZenMontageFilter, "MontageEnd", var))
       {
         return AbstractFilter::NullPointer();
       }
@@ -503,8 +547,8 @@ AbstractFilter::Pointer VSFilterFactory::createImportZeissZenMontageFilter(const
 // -----------------------------------------------------------------------------
 AbstractFilter::Pointer VSFilterFactory::createImportZeissMontageFilter(const QString& zeissFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, const QString& metaAmName,
                                                                         bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin,
-                                                                        IntVec3Type montageStart, IntVec3Type montageEnd, bool changeSpacing, FloatVec3Type spacing)
-  {
+                                                                        IntVec2Type montageStart, IntVec2Type montageEnd, bool changeSpacing, FloatVec3Type spacing)
+{
   // Instantiate Import AxioVision V4 Montage filter
   QString filterName = "ImportAxioVisionV4Montage";
   FilterManager* fm = FilterManager::Instance();
@@ -520,6 +564,20 @@ AbstractFilter::Pointer VSFilterFactory::createImportZeissMontageFilter(const QS
       // Set the path for the Robomet Configuration File
       var.setValue(zeissFile);
       if(!setFilterProperty(importZeissMontageFilter, "InputFile", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage start
+      var.setValue(montageStart);
+      if(!setFilterProperty(importZeissMontageFilter, "MontageStart", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage end
+      var.setValue(montageEnd);
+      if(!setFilterProperty(importZeissMontageFilter, "MontageEnd", var))
       {
         return AbstractFilter::NullPointer();
       }
@@ -629,7 +687,7 @@ AbstractFilter::Pointer VSFilterFactory::createImportZeissMontageFilter(const QS
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AbstractFilter::Pointer VSFilterFactory::createPCMTileRegistrationFilter(IntVec3Type montageStart, IntVec3Type montageEnd, const QString &dcPrefix, const QString& amName, const QString& daName)
+AbstractFilter::Pointer VSFilterFactory::createPCMTileRegistrationFilter(IntVec2Type montageStart, IntVec2Type montageEnd, const QString& dcPrefix, const QString& amName, const QString& daName)
 {
   QString filterName = "ITKPCMTileRegistration";
   FilterManager* fm = FilterManager::Instance();
@@ -687,7 +745,7 @@ AbstractFilter::Pointer VSFilterFactory::createPCMTileRegistrationFilter(IntVec3
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AbstractFilter::Pointer VSFilterFactory::createTileStitchingFilter(IntVec3Type montageSize, const QStringList &dcNames, const QString& amName, const QString& daName, const DataArrayPath &montagePath)
+AbstractFilter::Pointer VSFilterFactory::createTileStitchingFilter(IntVec3Type montageSize, const QStringList& dcNames, const QString& amName, const QString& daName, const DataArrayPath& montagePath)
 {
   QString filterName = "ITKStitchMontage";
   FilterManager* fm = FilterManager::Instance();
@@ -858,7 +916,7 @@ AbstractFilter::Pointer VSFilterFactory::createImageFileWriterFilter(const QStri
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-bool VSFilterFactory::setFilterProperty(const AbstractFilter::Pointer &filter, const char* propertyName, const QVariant &value)
+bool VSFilterFactory::setFilterProperty(const AbstractFilter::Pointer& filter, const char* propertyName, const QVariant& value)
 {
   if(!filter->setProperty(propertyName, value))
   {

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
@@ -745,7 +745,8 @@ AbstractFilter::Pointer VSFilterFactory::createPCMTileRegistrationFilter(IntVec2
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AbstractFilter::Pointer VSFilterFactory::createTileStitchingFilter(IntVec3Type montageSize, const QStringList& dcNames, const QString& amName, const QString& daName, const DataArrayPath& montagePath)
+AbstractFilter::Pointer VSFilterFactory::createTileStitchingFilter(IntVec2Type montageStart, IntVec2Type montageEnd, const QStringList& dcNames, const QString& amName, const QString& daName,
+                                                                   const DataArrayPath& montagePath)
 {
   QString filterName = "ITKStitchMontage";
   FilterManager* fm = FilterManager::Instance();
@@ -758,9 +759,16 @@ AbstractFilter::Pointer VSFilterFactory::createTileStitchingFilter(IntVec3Type m
     {
       QVariant var;
 
-      // Set montage size
-      var.setValue(montageSize);
-      if(!setFilterProperty(itkStitchingFilter, "MontageSize", var))
+      // Set montage start
+      var.setValue(montageStart);
+      if(!setFilterProperty(itkStitchingFilter, "MontageStart", var))
+      {
+        return AbstractFilter::NullPointer();
+      }
+
+      // Set montage end
+      var.setValue(montageEnd);
+      if(!setFilterProperty(itkStitchingFilter, "MontageEnd", var))
       {
         return AbstractFilter::NullPointer();
       }

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
@@ -415,7 +415,8 @@ AbstractFilter::Pointer VSFilterFactory::createImportRobometMontageFilter(const 
 //
 // -----------------------------------------------------------------------------
 AbstractFilter::Pointer VSFilterFactory::createImportZeissMontageFilter(const QString& zeissFile, const QString& dcPrefix, const QString& amName, const QString& daName, const QString metaAmName,
-                                                                        bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin, bool usePixelCoordinates, bool changeSpacing, FloatVec3Type spacing)
+                                                                        bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin,
+                                                                        IntVec3Type montageStart, IntVec3Type montageEnd, bool usePixelCoordinates, bool changeSpacing, FloatVec3Type spacing)
 {
   // Instantiate Import AxioVision V4 Montage filter
   QString filterName = "ImportAxioVisionV4Montage";

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
@@ -188,8 +188,8 @@ AbstractFilter::Pointer VSFilterFactory::createSetOriginResolutionFilter(const Q
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QString& fijiFile, const QString& dcPrefix, const QString& amName, const QString& daName, bool changeOrigin, float* origin,
-                                                                       bool usePixelCoordinates, bool changeSpacing, float* spacing, int32_t lengthUnit)
+AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QString& fijiFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, bool changeOrigin,
+                                                                       const float* origin, IntVec3Type montageStart, IntVec3Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit)
 {
   QString filterName = "ITKImportFijiMontage";
   FilterManager* fm = FilterManager::Instance();
@@ -204,7 +204,7 @@ AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QSt
 
       // Set the path for the Fiji Configuration File
       var.setValue(fijiFile);
-      if(!setFilterProperty(importFijiMontageFilter, "FijiConfigFilePath", var))
+      if(!setFilterProperty(importFijiMontageFilter, "InputFile", var))
       {
         return AbstractFilter::NullPointer();
       }
@@ -249,15 +249,9 @@ AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QSt
         }
       }
 
-      var.setValue(usePixelCoordinates);
-      if(!setFilterProperty(importFijiMontageFilter, "UsePixelCoordinates", var))
-      {
-        return AbstractFilter::NullPointer();
-      }
-
       // Set the Data Container Prefix
-      var.setValue(dcPrefix);
-      if(!setFilterProperty(importFijiMontageFilter, "DataContainerPrefix", var))
+      var.setValue(dcPath);
+      if(!setFilterProperty(importFijiMontageFilter, "DataContainerPath", var))
       {
         return AbstractFilter::NullPointer();
       }
@@ -271,7 +265,7 @@ AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QSt
 
       // Set the Image Array Name
       var.setValue(daName);
-      if(!setFilterProperty(importFijiMontageFilter, "AttributeArrayName", var))
+      if(!setFilterProperty(importFijiMontageFilter, "ImageDataArrayName", var))
       {
         return AbstractFilter::NullPointer();
       }

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.cpp
@@ -188,8 +188,8 @@ AbstractFilter::Pointer VSFilterFactory::createSetOriginResolutionFilter(const D
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QString& fijiFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName,
-                                                                       bool changeOrigin, const float* origin, bool changeSpacing, const float* spacing, int32_t lengthUnit)
+AbstractFilter::Pointer VSFilterFactory::createImportFijiMontageFilter(const QString& fijiFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, bool changeOrigin,
+                                                                       const float* origin, IntVec3Type montageStart, IntVec3Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit)
 {
   QString filterName = "ITKImportFijiMontage";
   FilterManager* fm = FilterManager::Instance();

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
@@ -162,14 +162,16 @@ public:
 
   /**
    * @brief Creates a PCM Tile Registration filter, and sets all necessary properties
-   * @param montageSize The size of the montage that is being registered
+   * @param montageStart The start of the montage that is being stitched
+   * @param montageEnd The end of the montage that is being stitched
    * @param dcNames List of data container names that contain the image files from the montage
    * @param amName Common attribute matrix name in each data container
    * @param daName Common data array name in each common attribute matrix
    * @param montagePath The path to the created montage data array
    * @return
    */
-  AbstractFilter::Pointer createTileStitchingFilter(IntVec3Type montageSize, const QStringList& dcNames, const QString& amName, const QString& daName, const DataArrayPath& montagePath);
+  AbstractFilter::Pointer createTileStitchingFilter(IntVec2Type montageStart, IntVec2Type montageEnd, const QStringList& dcNames, const QString& amName, const QString& daName,
+                                                    const DataArrayPath& montagePath);
 
   /**
    * @brief Creates a Set Origin Resolution filter that sets the origin and resolution of a data container's image geometry

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
@@ -80,7 +80,7 @@ public:
    * @return
    */
   AbstractFilter::Pointer createImportFijiMontageFilter(const QString& fijiFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, bool changeOrigin, const float* origin,
-                                                        IntVec3Type montageStart, IntVec3Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit);
+                                                        IntVec2Type montageStart, IntVec2Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit);
 
   /**
    * @brief Creates a filter that imports a Robomet montage, and sets all the necessary properties
@@ -94,15 +94,16 @@ public:
    * @param changeOrigin Boolean that overrides the origins in the image files.
    * @param origin XYZ origin array that overrides the origins from the image files.  This parameter
    * isn't needed if changeOrigin is false.
-   * @param usePixelCoordinates Boolean that determines whether the origin values are in pixel coordinates
+   * @param montageStart The starting column and row of the montage
+   * @param montageEnd The ending column and row of the montage
    * @param changeSpacing Boolean that overrides the spacings coming from the image files.
    * @param spacing XYZ spacing array that overrides the spacings from the image files.  This parameter
    * isn't needed if changeSpacing is false.
    * @return
    */
   AbstractFilter::Pointer createImportRobometMontageFilter(const QString& robometFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, int sliceNumber,
-                                                           const QString& imageFilePrefix, const QString& imageFileExtension, bool changeOrigin, const float* origin,
-                                                           bool changeSpacing, const float* spacing, int32_t lengthUnit);
+                                                           const QString& imageFilePrefix, const QString& imageFileExtension, bool changeOrigin, const float* origin, IntVec2Type montageStart,
+                                                           IntVec2Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit);
 
   /**
    * @brief Creates a filter that imports a Zeiss montage, and sets all the necessary properties
@@ -126,30 +127,27 @@ public:
    * @return
    */
   AbstractFilter::Pointer createImportZeissMontageFilter(const QString& zeissFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, const QString& metaAmName,
-                                                         bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin, IntVec3Type montageStart,
-                                                         IntVec3Type montageEnd, bool changeSpacing, FloatVec3Type spacing);
-  
+                                                         bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin, IntVec2Type montageStart,
+                                                         IntVec2Type montageEnd, bool changeSpacing, FloatVec3Type spacing);
+
   /**
    * @brief Creates a filter that imports a Zeiss Zen montage, and sets all the necessary properties
    * @param zeissFile The Zeiss Zen file path
    * @param dcPath The path to the data containers the image data will be stored in
    * @param amName The name of the attribute matrix that the image data will be stored in
    * @param daName The name of the image data array
-   * @param metaAmName The name of the image metadata array
-   * @param importAllMetadata Boolean that imports all of the image metadata
    * @param convertToGrayscale Boolean that converts the image data to grayscale
    * @param colorWeights RGB array of color weights used during the grayscale conversion.  This parameter
    * isn't needed if convertToGrayscale is false.
    * @param changeOrigin Boolean that overrides the origins in the image files.
    * @param origin XYZ origin array that overrides the origins from the image files.  This parameter
    * isn't needed if changeOrigin is false.
-   * @param changeSpacing Boolean that overrides the spacings coming from the image files.
-   * @param spacing XYZ spacing array that overrides the spacings from the image files.  This parameter
-   * isn't needed if changeSpacing is false.
+   * @param montageStart The starting column and row of the montage
+   * @param montageEnd The ending column and row of the montage
    * @return
    */
   AbstractFilter::Pointer createImportZeissZenMontageFilter(const QString& zeissFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, bool convertToGrayscale,
-                                                            FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin);
+                                                            FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin, IntVec2Type montageStart, IntVec2Type montageEnd);
 
   /**
    * @brief Creates a PCM Tile Registration filter, and sets all necessary properties
@@ -160,7 +158,7 @@ public:
    * @param daName Common data array name in each common attribute matrix
    * @return
    */
-  AbstractFilter::Pointer createPCMTileRegistrationFilter(IntVec3Type montageStart, IntVec3Type montageEnd, const QString &dcPrefix, const QString& amName, const QString& daName);
+  AbstractFilter::Pointer createPCMTileRegistrationFilter(IntVec2Type montageStart, IntVec2Type montageEnd, const QString& dcPrefix, const QString& amName, const QString& daName);
 
   /**
    * @brief Creates a PCM Tile Registration filter, and sets all necessary properties
@@ -171,7 +169,7 @@ public:
    * @param montagePath The path to the created montage data array
    * @return
    */
-  AbstractFilter::Pointer createTileStitchingFilter(IntVec3Type montageSize, const QStringList &dcNames, const QString& amName, const QString& daName, const DataArrayPath &montagePath);
+  AbstractFilter::Pointer createTileStitchingFilter(IntVec3Type montageSize, const QStringList& dcNames, const QString& amName, const QString& daName, const DataArrayPath& montagePath);
 
   /**
    * @brief Creates a Set Origin Resolution filter that sets the origin and resolution of a data container's image geometry
@@ -182,7 +180,7 @@ public:
    * @param origin The origin to set into the image geometry
    * @return
    */
-  AbstractFilter::Pointer createSetOriginResolutionFilter(const DataArrayPath &dcPath, bool changeResolution, bool changeOrigin, FloatVec3Type resolution, FloatVec3Type origin);
+  AbstractFilter::Pointer createSetOriginResolutionFilter(const DataArrayPath& dcPath, bool changeResolution, bool changeOrigin, FloatVec3Type resolution, FloatVec3Type origin);
 
   /**
    * @brief Creates a Data Container Reader filter that reads the data from a DREAM3D file and sets all necessary properties
@@ -190,7 +188,7 @@ public:
    * @param inputFileDCAProxy The proxy structure from the DREAM3D file
    * @return
    */
-  AbstractFilter::Pointer createDataContainerReaderFilter(const QString& inputFile, const DataContainerArrayProxy &inputFileDCAProxy);
+  AbstractFilter::Pointer createDataContainerReaderFilter(const QString& inputFile, const DataContainerArrayProxy& inputFileDCAProxy);
 
   /**
    * @brief Creates a Data Container Writer filter that write the data to a DREAM3D file and sets all necessary properties
@@ -232,11 +230,11 @@ private:
    * @param propertyName
    * @param value
    */
-  bool setFilterProperty(const AbstractFilter::Pointer &filter, const char* propertyName, const QVariant &value);
+  bool setFilterProperty(const AbstractFilter::Pointer& filter, const char* propertyName, const QVariant& value);
 
 public:
-  VSFilterFactory(const VSFilterFactory&) = delete; // Copy Constructor Not Implemented
-  VSFilterFactory(VSFilterFactory&&) = delete;      // Move Constructor Not Implemented
+  VSFilterFactory(const VSFilterFactory&) = delete;            // Copy Constructor Not Implemented
+  VSFilterFactory(VSFilterFactory&&) = delete;                 // Move Constructor Not Implemented
   VSFilterFactory& operator=(const VSFilterFactory&) = delete; // Copy Assignment Not Implemented
   VSFilterFactory& operator=(VSFilterFactory&&) = delete;      // Move Assignment Not Implemented
 };

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
@@ -66,21 +66,21 @@ public:
   /**
    * @brief Creates a filter that imports a Fiji montage, and sets all the necessary properties
    * @param robometFile The Fiji file path
-   * @param dcPrefix The prefix of the data containers the image data will be stored in
+   * @param dcPath The path to the data containers the image data will be stored in
    * @param amName The name of the attribute matrix that the image data will be stored in
    * @param daName The name of the image data array
    * @param changeOrigin Boolean that overrides the origins in the image files.
    * @param origin XYZ origin array that overrides the origins from the image files.  This parameter
    * isn't needed if changeOrigin is false.
-   * @param usePixelCoordinates Boolean that determines whether the origin values are in pixel coordinates
+   * @param montageStart The starting column and row of the montage
+   * @param montageEnd The ending column and row of the montage
    * @param changeSpacing Boolean that overrides the spacings coming from the image files.
    * @param spacing XYZ spacing array that overrides the spacings from the image files.  This parameter
    * isn't needed if changeSpacing is false.
    * @return
    */
-  AbstractFilter::Pointer createImportFijiMontageFilter(const QString& fijiFile, const QString& dcPrefix, const QString& amName, const QString& daName, bool changeOrigin, float* origin,
-                                                        bool usePixelCoordinates, bool changeSpacing, float* spacing, int32_t lengthUnit);
-
+  AbstractFilter::Pointer createImportFijiMontageFilter(const QString& fijiFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, bool changeOrigin, const float* origin,
+                                                        IntVec3Type montageStart, IntVec3Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit);
   /**
    * @brief Creates a filter that imports a Robomet montage, and sets all the necessary properties
    * @param robometFile The Robomet file path

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
@@ -117,6 +117,8 @@ public:
    * @param changeOrigin Boolean that overrides the origins in the image files.
    * @param origin XYZ origin array that overrides the origins from the image files.  This parameter
    * isn't needed if changeOrigin is false.
+   * @param montageStart The starting column and row of the montage
+   * @param montageEnd The ending column and row of the montage
    * @param usePixelCoordinates Boolean that determines whether the origin values are in pixel coordinates
    * @param changeSpacing Boolean that overrides the spacings coming from the image files.
    * @param spacing XYZ spacing array that overrides the spacings from the image files.  This parameter
@@ -124,7 +126,8 @@ public:
    * @return
    */
   AbstractFilter::Pointer createImportZeissMontageFilter(const QString& zeissFile, const QString& dcPrefix, const QString& amName, const QString& daName, const QString metaAmName,
-                                                         bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin, bool usePixelCoordinates, bool changeSpacing, FloatVec3Type spacing);
+                                                         bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin, IntVec3Type montageStart,
+                                                         IntVec3Type montageEnd, bool usePixelCoordinates, bool changeSpacing, FloatVec3Type spacing);
 
   /**
    * @brief Creates a PCM Tile Registration filter, and sets all necessary properties

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
@@ -72,13 +72,15 @@ public:
    * @param changeOrigin Boolean that overrides the origins in the image files.
    * @param origin XYZ origin array that overrides the origins from the image files.  This parameter
    * isn't needed if changeOrigin is false.
+   * @param montageStart The starting column and row of the montage
+   * @param montageEnd The ending column and row of the montage
    * @param changeSpacing Boolean that overrides the spacings coming from the image files.
    * @param spacing XYZ spacing array that overrides the spacings from the image files.  This parameter
    * isn't needed if changeSpacing is false.
    * @return
    */
-  AbstractFilter::Pointer createImportFijiMontageFilter(const QString& fijiFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName,
-                                                        bool changeOrigin, const float* origin, bool changeSpacing, const float* spacing, int32_t lengthUnit);
+  AbstractFilter::Pointer createImportFijiMontageFilter(const QString& fijiFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, bool changeOrigin, const float* origin,
+                                                        IntVec3Type montageStart, IntVec3Type montageEnd, bool changeSpacing, const float* spacing, int32_t lengthUnit);
 
   /**
    * @brief Creates a filter that imports a Robomet montage, and sets all the necessary properties

--- a/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
+++ b/SIMPLVtkLib/QtWidgets/VSFilterFactory.h
@@ -118,14 +118,16 @@ public:
    * @param changeOrigin Boolean that overrides the origins in the image files.
    * @param origin XYZ origin array that overrides the origins from the image files.  This parameter
    * isn't needed if changeOrigin is false.
+   * @param montageStart The starting column and row of the montage
+   * @param montageEnd The ending column and row of the montage
    * @param changeSpacing Boolean that overrides the spacings coming from the image files.
    * @param spacing XYZ spacing array that overrides the spacings from the image files.  This parameter
    * isn't needed if changeSpacing is false.
    * @return
    */
-  AbstractFilter::Pointer createImportZeissMontageFilter(const QString& zeissFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName,
-                                                         const QString &metaAmName, bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights,
-                                                         bool changeOrigin, FloatVec3Type origin, bool changeSpacing, FloatVec3Type spacing);
+  AbstractFilter::Pointer createImportZeissMontageFilter(const QString& zeissFile, const DataArrayPath& dcPath, const QString& amName, const QString& daName, const QString& metaAmName,
+                                                         bool importAllMetadata, bool convertToGrayscale, FloatVec3Type colorWeights, bool changeOrigin, FloatVec3Type origin, IntVec3Type montageStart,
+                                                         IntVec3Type montageEnd, bool changeSpacing, FloatVec3Type spacing);
   
   /**
    * @brief Creates a filter that imports a Zeiss Zen montage, and sets all the necessary properties


### PR DESCRIPTION
Added Montage Start and Montage End fields to each of the montage import dialogs.
Allows user to only register and stitch a montage of the requested tiles in the range of montage start / end for column and row.